### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var htmlparser = require('htmlparser2');
 var _ = require('lodash');
-var ent = require('ent');
+var he = require('he');
 
 module.exports = sanitizeHtml;
 
@@ -154,7 +154,7 @@ function sanitizeHtml(html, options) {
 
   function naughtyHref(href) {
     // So we don't get faked out by a hex or decimal escaped javascript URL #1
-    href = ent.decode(href);
+    href = he.decode(href);
     // Browsers ignore character codes of 32 (space) and below in a surprising
     // number of situations. Start reading here:
     // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Embedded_tab

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
-    "lodash": "2.4.x",
+    "he": "~0.4.1",
     "htmlparser2": "~3.3.0",
-    "ent": "~0.1.0"
+    "lodash": "2.4.x"
   }
 }


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
