### PR TITLE
Protect against comments in URI schemes (i.e. java<!-- -->script)

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,8 +201,9 @@ function sanitizeHtml(html, options) {
     // number of situations. Start reading here:
     // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Embedded_tab
     href = href.replace(/[\x00-\x20]+/, '');
-    // Case insensitive so we don't get faked out by JAVASCRIPT #1
-    var matches = href.match(/^([a-zA-Z]+)\:/);
+    // Match all possible strings so we don't get faked out by JAVASCRIPT #1
+    // or even malformed CDATA (i.e. java<!-- -->script:alert('XSS'); )
+    var matches = href.match(/^([^:]+)\:/);
     if (!matches) {
       // No scheme = no way to inject js (right?)
       return false;


### PR DESCRIPTION
It is possible to inject the following:

```
<XML ID="xss"><I><B><IMG SRC="javas<!-- -->cript:alert('XSS')"></B></I></XML>
<SPAN DATASRC="#xss" DATAFLD="B" DATAFORMATAS="HTML"></SPAN>
```

which (assuming 'i', 'b', 'img' and 'src' are permitted), will yield:

```
<I><B><IMG SRC="javas<!-- -->cript:alert('XSS');"></B></I>
```

While I'm not sure that this is ever interpreted by browsers without an [XML data island](https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#XML_data_island_with_CDATA_obfuscation) (which is stripped by your default tag whitelist), it is still worrying to see the attack payload appear in output, so here's a fix.
