### PR TITLE
Allow access to element's attributes in exclusiveFilter callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ sanitizeHtml(
 );
 ```
 
+The `frame` object provides the following properties:
+
+ - `tag`: The name of the tag, lowercased.
+ - `attribs`: A key/value pairing of the element's attributes. Keys are lowercased.
+ - `text`: The text content of the tag.
+
 ### Allowed CSS Classes
 
 If you wish to allow specific CSS classes on a particular element, you can do so with the `allowedClasses` option. Any other CSS classes are discarded.


### PR DESCRIPTION
I've done this so that an exclusiveFilter can, for example, filter `<img>` tags with no (or empty) `src` attribute.

Note that I may be making more pull requests today! This is by far the best JS-based HTML sanitizer I've found, and I may well use it in production once all my tests are passing ;)
