### PR TITLE
Allow access to element's attributes in exclusiveFilter callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ sanitizeHtml(
 );
 ```
 
+The `frame` object supplied to the callback provides the following attributes:
+
+ - `tag`: The tag name, i.e. `'img'`.
+ - `attribs`: The tag's attributes, i.e. `{ src: "/path/to/tux.png" }`.
+ - `text`: The text content of the tag.
+ - `tagPosition`: The index of the tag's position in the result string.
+
 ### Allowed CSS Classes
 
 If you wish to allow specific CSS classes on a particular element, you can do so with the `allowedClasses` option. Any other CSS classes are discarded.

--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ module.exports = sanitizeHtml;
 function sanitizeHtml(html, options) {
   var result = '';
 
-  function Frame(tag) {
+  function Frame(tag, attribs) {
     var that = this;
     this.tag = tag;
+    this.attribs = attribs || {};
     this.tagPosition = result.length;
     this.text = ''; // Node inner text
 
@@ -78,16 +79,16 @@ function sanitizeHtml(html, options) {
   var skipText = false;
   var parser = new htmlparser.Parser({
     onopentag: function(name, attribs) {
-     var frame = new Frame(name);
+     var frame = new Frame(name, attribs);
      stack.push(frame);
 
       var skip = false;
       if (_.has(transformTagsMap, name)) {
         var transformedTag = transformTagsMap[name](name, attribs);
 
-        attribs = transformedTag.attribs;
+        frame.attribs = attribs = transformedTag.attribs;
         if (name !== transformedTag.tagName) {
-          name = transformedTag.tagName;
+          frame.name = name = transformedTag.tagName;
           transformMap[depth] = transformedTag.tagName;
         }
       }
@@ -110,12 +111,14 @@ function sanitizeHtml(html, options) {
           if (_.has(allowedAttributesMap[name], a)) {
             if ((a === 'href') || (a === 'src')) {
               if (naughtyHref(value)) {
+                delete frame.attribs[a];
                 return;
               }
             }
             if (a === 'class') {
               value = filterClasses(value, allowedClassesMap[name]);
               if (!value.length) {
+                delete frame.attribs[a];
                 return;
               }
             }
@@ -125,6 +128,8 @@ function sanitizeHtml(html, options) {
               // results in double escapes
               result += '="' + value + '"';
             }
+          } else {
+            delete frame.attribs[a];
           }
         });
       }
@@ -165,7 +170,7 @@ function sanitizeHtml(html, options) {
         delete transformMap[depth];
       }
 
-      if (options.exclusiveFilter && options.exclusiveFilter(frame)) {
+      if (options.exclusiveFilter && options.exclusiveFilter(_.cloneDeep(frame))) {
          result = result.substr(0, frame.tagPosition);
          return;
       }


### PR DESCRIPTION
Sorry for the dodgy pull request before - got it right this time!

Essentially the idea here is to allow the definition of an exclusive filter like this:

``` javascript
exclusiveFilter: function(frame) {
    return frame.tag === 'img' && !(frame.attribs.src || '').trim();
}
```

which would filter images with no `src`.

Note that I've used `_.cloneDeep` to prevent alteration of the `frame` from inside the callback, or calling its method(s).
