### PR TITLE
Option to turn off whitelist for tags and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ If you do not specify `allowedTags` or `allowedAttributes` our default list is a
     // URL schemes we permit
     allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ]
 
+"What if I want to allow all tags or all attributes?"
+
+Simple! instead of leaving `allowedTags` or `allowedAttributes` out of the options, set either
+one or both to `false`:
+
+    allowedTags: false,
+    allowedAttributes: false
+
+
 ### Transformations
 
 What if you want to add or change an attribute? What if you want to transform one tag to another? No problem, it's simple!
@@ -224,4 +233,3 @@ We're rocking our tests and have been working great in production for months, so
 Feel free to open issues on [github](http://github.com/punkave/sanitize-html).
 
 <a href="http://punkave.com/"><img src="https://raw.github.com/punkave/sanitize-html/master/logos/logo-box-builtby.png" /></a>
-

--- a/index.js
+++ b/index.js
@@ -34,28 +34,36 @@ function sanitizeHtml(html, options) {
     script: true,
     style: true
   };
-  var allowedTagsMap = {};
-  _.each(options.allowedTags, function(tag) {
-    allowedTagsMap[tag] = true;
-  });
+  var allowedTagsMap;
+  if(options.allowedTags) {
+    allowedTagsMap = {};
+    _.each(options.allowedTags, function(tag) {
+      allowedTagsMap[tag] = true;
+    });
+  }
   var selfClosingMap = {};
   _.each(options.selfClosing, function(tag) {
     selfClosingMap[tag] = true;
   });
-  var allowedAttributesMap = {};
-  _.each(options.allowedAttributes, function(attributes, tag) {
-    allowedAttributesMap[tag] = {};
-    _.each(attributes, function(name) {
-      allowedAttributesMap[tag][name] = true;
+  var allowedAttributesMap;
+  if(options.allowedAttributes) {
+    allowedAttributesMap = {};
+    _.each(options.allowedAttributes, function(attributes, tag) {
+      allowedAttributesMap[tag] = {};
+      _.each(attributes, function(name) {
+        allowedAttributesMap[tag][name] = true;
+      });
     });
-  });
+  }
   var allowedClassesMap = {};
   _.each(options.allowedClasses, function(classes, tag) {
     // Implicitly allows the class attribute
-    if (!allowedAttributesMap[tag]) {
-      allowedAttributesMap[tag] = {};
+    if(allowedAttributesMap) {
+      if (!allowedAttributesMap[tag]) {
+        allowedAttributesMap[tag] = {};
+      }
+      allowedAttributesMap[tag]['class'] = true;
     }
-    allowedAttributesMap[tag]['class'] = true;
 
     allowedClassesMap[tag] = {};
     _.each(classes, function(name) {
@@ -93,7 +101,7 @@ function sanitizeHtml(html, options) {
         }
       }
 
-      if (!_.has(allowedTagsMap, name)) {
+      if (allowedTagsMap && !_.has(allowedTagsMap, name)) {
         skip = true;
         if (_.has(nonTextTagsMap, name)) {
           skipText = true;
@@ -106,9 +114,9 @@ function sanitizeHtml(html, options) {
         return;
       }
       result += '<' + name;
-      if (_.has(allowedAttributesMap, name)) {
+      if (!allowedAttributesMap || _.has(allowedAttributesMap, name)) {
         _.each(attribs, function(value, a) {
-          if (_.has(allowedAttributesMap[name], a)) {
+          if (!allowedAttributesMap || _.has(allowedAttributesMap[name], a)) {
             if ((a === 'href') || (a === 'src')) {
               if (naughtyHref(value)) {
                 delete frame.attribs[a];

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,12 @@ describe('sanitizeHtml', function() {
   it('should pass through simple well-formed whitelisted markup', function() {
     assert.equal(sanitizeHtml('<div><p>Hello <b>there</b></p></div>'), '<div><p>Hello <b>there</b></p></div>');
   });
+  it('should pass through all markup if allowedTags and allowedAttributes are set to false', function() {
+    assert.equal(sanitizeHtml('<div><wiggly worms="ewww">hello</wiggly></div>', {
+      allowedTags: false,
+      allowedAttributes: false
+    }), '<div><wiggly worms="ewww">hello</wiggly></div>');
+  });
   it('should respect text nodes at top level', function() {
     assert.equal(sanitizeHtml('Blah blah blah<p>Whee!</p>'), 'Blah blah blah<p>Whee!</p>');
   });
@@ -222,4 +228,3 @@ describe('sanitizeHtml', function() {
     );
   });
 });
-


### PR DESCRIPTION
Turn off whitelisting filter (i.e., allow all through) by setting `allowedTags` or `allowedAttributes` options to `false`.

This was the simplest/quickest way for me to get the flexibility I needed in the moment for something I'm doing.  Not sure if it's a feature you'd want, or whether a different design would be preferable, but figured I'd offer this one anyway.
