### PR TITLE
Pass stack (parent nodes) to textFilter()

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ function sanitizeHtml(html, options, _recursing) {
       } else {
         var escaped = escapeHtml(text);
         if (options.textFilter) {
-          result += options.textFilter(escaped);
+          result += options.textFilter(escaped, stack.slice().reverse());
         } else {
           result += escaped;
         }


### PR DESCRIPTION
Would be great to have more context when processing text nodes, i.e. using textFilter(). Real-world use-case: Looking for plain-text URLs or mail addresses and turn them into clickable links. However, you don't want to do that if the parent node is already a link. Passing stack (actually in a reverse order is more convenient) would help a lot.
