### PR TITLE
Adds frame.children array

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function sanitizeHtml(html, options, _recursing) {
     this.tag = tag;
     this.attribs = attribs || {};
     this.tagPosition = result.length;
+    this.children = [];
     this.text = ''; // Node inner text
 
     this.updateParentNodeText = function() {
@@ -35,6 +36,13 @@ function sanitizeHtml(html, options, _recursing) {
           parentFrame.text += that.text;
       }
     };
+
+    this.updateParentNodeChildren = function() {
+      if (stack.length) {
+        var parentFrame = stack[stack.length - 1];
+        parentFrame.children.push(this.tag);
+      }
+    }
   }
 
   if (!options) {
@@ -258,6 +266,7 @@ function sanitizeHtml(html, options, _recursing) {
          return;
       }
 
+      frame.updateParentNodeChildren();
       frame.updateParentNodeText();
 
       if (options.selfClosing.indexOf(name) !== -1) {

--- a/test/test.js
+++ b/test/test.js
@@ -186,6 +186,32 @@ describe('sanitizeHtml', function() {
             ''
         );
   });
+  it('Should not collapse elements containing only self closing tags', function() {
+    var tux = 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png?1463231285282';
+    var markup = '<a href="http://www.linux.org"><img src="'+ tux +'" /></a>'
+    assert.strictEqual(
+      sanitizeHtml(markup, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+        exclusiveFilter: function(frame) {
+          return (frame.tag === 'a') && !frame.text.trim() && !frame.children.length;
+        }
+      }),
+      markup
+    )
+  });
+  it('Should not collapse elements containing specified tags', function() {
+    var tux = 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png?1463231285282';
+    var markup = '<a href="http://www.linux.org"><img src="'+ tux +'" /></a>'
+    assert.strictEqual(
+      sanitizeHtml(markup, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+        exclusiveFilter: function(frame) {
+          return (frame.tag === 'a' && frame.children.length === 1 && !frame.children.indexOf('img') === -1);
+        }
+      }),
+      markup
+    )
+  });
   it('Exclusive filter should not affect elements which do not match the filter condition', function () {
       assert.strictEqual(
           sanitizeHtml('I love <a href="www.linux.org" target="_hplink">Linux</a> OS',


### PR DESCRIPTION
This PR is in response to some undesired behaviour that I wasn't able to overcome with the current API.

Consider a situation where I want to allow anchors, but only when they either contain text nodes, or other nodes. Checking for `frame.text` in the `exclusiveFilter()` is generally sufficient - but will fail where all inner nodes are self closing tags (and hence don't contain text nodes).

So, for example:

``` js
sanitizeHtml('<a href="http://x.com"><img src="http://x.com/img.png" /></a>', {
    allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
    exclusiveFilter: function(frame) {
      return frame.tag === 'a' && !frame.text.trim();
    }
  }
); // => ''
```

This PR just adds an extra property (`children`) to the frame passed to `exclusiveFilter()`. `frame.children` is an array containing the tag names of any child nodes, it can be used to assert that a `frame` with empty `.text` contains self closing nodes.

It could also be used to further tune the behaviour of 'exclusiveFilter()', for example, to allow only anchors that contain a single image tag as per this [this test cases](https://github.com/punkave/sanitize-html/compare/master...axdg:master#diff-c1129c8b045390789fa8ff62f2c6b4a9R202).
