### PR TITLE
Escape disallowed tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,16 @@ Note that if you use this option you are responsible for stating the entire list
 
 The content still gets escaped properly, with the exception of the `script` and `style` tags. *Allowing either `script` or `style` leaves you open to XSS attacks. Don't do that* unless you have good reason to trust their origin.
 
+### Escaping the content of a disallowed tag
+
+Instead of discarding, or keeping text only, you may enable escaping of the entire content:
+
+```javascript
+escapeDisallowedTags: true
+```
+
+This will transform `<disallowed>content</disallowed>` to `&lt;disallowed&gt;content&lt;/disallowed&gt;`
+
 ## About P'unk Avenue and Apostrophe
 
 `sanitize-html` was created at [P'unk Avenue](http://punkave.com) for use in ApostropheCMS, an open-source content management system built on node.js. If you like `sanitize-html` you should definitely [check out apostrophecms.org](http://apostrophecms.org).

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ const VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
 
 function sanitizeHtml(html, options, _recursing) {
   var result = '';
+  var tempResult = '';
 
   function Frame(tag, attribs) {
     var that = this;
@@ -137,6 +138,7 @@ function sanitizeHtml(html, options, _recursing) {
   var skipMap = {};
   var transformMap = {};
   var skipText = false;
+  var escapeDepth = 0;
   var skipTextDepth = 0;
 
   var parser = new htmlparser.Parser({
@@ -144,6 +146,9 @@ function sanitizeHtml(html, options, _recursing) {
       if (skipText) {
         skipTextDepth++;
         return;
+      }
+      if (escapeDepth > 0) {
+        escapeDepth++;
       }
       var frame = new Frame(name, attribs);
       stack.push(frame);
@@ -177,16 +182,26 @@ function sanitizeHtml(html, options, _recursing) {
 
       if (options.allowedTags && options.allowedTags.indexOf(name) === -1) {
         skip = true;
-        if (nonTextTagsArray.indexOf(name) !== -1) {
-          skipText = true;
-          skipTextDepth = 1;
+        if (!options.escapeDisallowedTags) {
+          // We don't want to skip disallowedTags tags, just escape them
+          if (nonTextTagsArray.indexOf(name) !== -1) {
+            skipText = true;
+            skipTextDepth = 1;
+          }
+          skipMap[depth] = true;
         }
-        skipMap[depth] = true;
       }
       depth++;
       if (skip) {
-        // We want the contents but not this tag
-        return;
+        if (!options.escapeDisallowedTags) {
+          // We want the contents but not this tag
+          return;
+        }
+        if (escapeDepth === 0) {
+          tempResult = result;
+          result = '';
+          escapeDepth++;
+        }
       }
       result += '<' + name;
       if (!allowedAttributesMap || has(allowedAttributesMap, name) || allowedAttributesMap['*']) {
@@ -324,6 +339,10 @@ function sanitizeHtml(html, options, _recursing) {
       }
       if (options.selfClosing.indexOf(name) !== -1) {
         result += " />";
+        if (escapeDepth > 0 && --escapeDepth === 0) {
+          result = tempResult + escapeHtml(result);
+          tempResult = '';
+        }
       } else {
         result += ">";
         if (frame.innerText && !hasText && !options.textFilter) {
@@ -373,6 +392,7 @@ function sanitizeHtml(html, options, _recursing) {
           return;
         }
       }
+      var shouldEscape = escapeDepth > 0 && --escapeDepth === 0;
 
       var frame = stack.pop();
       if (!frame) {
@@ -405,6 +425,10 @@ function sanitizeHtml(html, options, _recursing) {
       }
 
       result += "</" + name + ">";
+      if (shouldEscape) {
+        result = tempResult + escapeHtml(result);
+        tempResult = '';
+      }
     }
   }, options.parser);
   parser.write(html);
@@ -572,6 +596,7 @@ sanitizeHtml.defaults = {
   allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
     'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
     'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe' ],
+  escapeDisallowedTags: false,
   allowedAttributes: {
     a: [ 'href', 'name', 'target' ],
     // We don't currently allow img itself by default, but this

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,9 @@ describe('sanitizeHtml', function() {
   it('should reject markup not whitelisted without destroying its text', function() {
     assert.equal(sanitizeHtml('<div><wiggly>Hello</wiggly></div>'), '<div>Hello</div>');
   });
+  it('should escape markup not whitelisted', function() {
+    assert.equal(sanitizeHtml('<div><wiggly>Hello</wiggly></div>', { escapeDisallowedTags: true }), '<div>&lt;wiggly&gt;Hello&lt;/wiggly&gt;</div>');
+  });
   it('should accept a custom list of allowed tags', function() {
     assert.equal(sanitizeHtml('<blue><red><green>Cheese</green></red></blue>', { allowedTags: [ 'blue', 'green' ] }), '<blue><green>Cheese</green></blue>');
   });
@@ -819,4 +822,22 @@ describe('sanitizeHtml', function() {
   //       }
   //     }), '<img src="&lt;0&amp;0;0.2&amp;" />');
   // });
+  it('should escape markup not whitelisted and all its children', function() {
+    assert.equal(
+        sanitizeHtml('<div><wiggly>Hello<p>World</p></wiggly></div>', { escapeDisallowedTags: true }),
+        '<div>&lt;wiggly&gt;Hello&lt;p&gt;World&lt;/p&gt;&lt;/wiggly&gt;</div>'
+    );
+  });
+  it('should escape markup even when deocdeEntities is false', function() {
+    assert.equal(
+        sanitizeHtml('<wiggly>Hello</wiggly>', { escapeDisallowedTags: true, parser: { decodeEntities: false } }),
+        '&lt;wiggly&gt;Hello&lt;/wiggly&gt;'
+    );
+  });
+  it('should escape markup not whitelisted even with not whitelisted children', function() {
+    assert.equal(
+        sanitizeHtml('<div><wiggly>Hello<p>World</p><tiggly>JS</tiggly></wiggly></div>', { escapeDisallowedTags: true }),
+        '<div>&lt;wiggly&gt;Hello&lt;p&gt;World&lt;/p&gt;&lt;tiggly&gt;JS&lt;/tiggly&gt;&lt;/wiggly&gt;</div>'
+    );
+  });
 });


### PR DESCRIPTION
Added the option to escape disallowed tags instead of stripping or discarding them. 
Escaping is a rather common use-case (a user naively sending `<span>hello</span>` would expect it to render like that, and not stripped down to `hello`), which is also referenced in #57 .