### PR TITLE
Removed toLowerCase from naughtyHref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -456,7 +456,7 @@ function sanitizeHtml(html, options, _recursing) {
       // No scheme
       return false;
     }
-    var scheme = matches[1].toLowerCase();
+    var scheme = matches[1];
 
     if (has(options.allowedSchemesByTag, name)) {
       return options.allowedSchemesByTag[name].indexOf(scheme) === -1;


### PR DESCRIPTION
Removed toLowerCase from naughtyHref to enable CAPITAL , lower and MiXed allowedSchemes are allowed. 
This was one of the blocker for me.