### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "browserify src/index.js > dist/sanitize-html-es2015.js --standalone 'sanitizeHtml' && babel dist/sanitize-html-es2015.js --out-file dist/sanitize-html.js --presets=@babel/preset-env",
     "minify": "npm run build && uglifyjs dist/sanitize-html.js > dist/sanitize-html.min.js",
     "prepublishOnly": "npm run minify",
-    "test": "npm run prepublishOnly && mocha test/test.js"
+    "test": "npm run build && mocha test/test.js"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 describe('sanitizeHtml', function() {
   var sanitizeHtml;
   it('should be successfully initialized', function() {
-    sanitizeHtml = require('../dist/index.js');
+    sanitizeHtml = require('../dist/sanitize-html.js');
   });
   it('should pass through simple well-formed whitelisted markup', function() {
     assert.equal(sanitizeHtml('<div><p>Hello <b>there</b></p></div>'), '<div><p>Hello <b>there</b></p></div>');


### PR DESCRIPTION
Tests were previously not running because the `npm` script was running `prepublishOnly` which was not producing `/dist/index.js`.

Now `npm run test` runs `build` which produces `/dist/sanitize-html.js` that mocha can use.