### PR TITLE
Fixed require statement in test.js

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 describe('sanitizeHtml', function() {
   var sanitizeHtml;
   it('should be successfully initialized', function() {
-    sanitizeHtml = require('../dist/index.js');
+    sanitizeHtml = require('../dist/sanitize-html.js');
   });
   it('should pass through simple well-formed whitelisted markup', function() {
     assert.equal(sanitizeHtml('<div><p>Hello <b>there</b></p></div>'), '<div><p>Hello <b>there</b></p></div>');


### PR DESCRIPTION
`npm test` is currently broken, this PR fixes it.
The problem was `require`-ing the wrong filename in `test.js` (`index.js` instead of `sanitize-html.js`).