### PR TITLE
Update chalk from v2 to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^3.0.0",
     "htmlparser2": "^3.10.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^2.4.1",
+    "chalk": "^3.0.0",
     "htmlparser2": "^3.10.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",


### PR DESCRIPTION
✅Tested that `npm test` passes.

Performance improvement: https://github.com/chalk/chalk/releases/tag/v3.0.0

...but wait, chalk isn't referenced or used anywhere in `sanitize-html`? There's an old backstory at https://github.com/apostrophecms/sanitize-html/issues/195

...different thing is this is relevant anymore. 🤷‍♂️