### PR TITLE
Update srcset dependency from v1 to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash.isstring": "^4.0.1",
     "lodash.mergewith": "^4.6.1",
     "postcss": "^7.0.5",
-    "srcset": "^1.0.0",
+    "srcset": "^2.0.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Seems mostly meta release and drops one dependency: https://github.com/sindresorhus/srcset/releases

Tested that `npm test` passes.