### PR TITLE
Demonstrate exclusiveFilter removing paragraph containing an image

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -435,6 +435,16 @@ describe('sanitizeHtml', function() {
       ''
     );
   });
+  it('should not remove paragraphs containing only an <img> tag', () => {
+    assert.equal(
+      sanitizeHtml('<p><img src="http://blah.net/blah.png" /></p>', {
+        exclusiveFilter: function (frame) {
+          return frame.tag === 'p' && !frame.text.trim();
+        }
+      }),
+      '<p><img src="http://blah.net/blah.png" /></p>'
+    );
+  });
   it('should allow transform on all tags using \'*\'', function () {
     assert.equal(
       sanitizeHtml(


### PR DESCRIPTION
This PR is **adding a failing test** to showcase the [following issue](https://github.com/apostrophecms/sanitize-html/issues/313) that we are currently having with the `exclusiveFilter` option.

**NOTE**: I am not the original author of the issue.

Consider the following case in which a user enters some text and an image in a markdown editor, adding one extra newline between the text and the image:

```markdown
Here, have this beautiful image:

![alt text](http://foo.net/bar.png)
```
This is the result of the conversion to HTML (**a paragraph is wrapping the image due to the 2 newlines**):
```html
<p>Here, have this beautiful image:</p>
<p><img src="http://foo.net/bar.png" alt="alt text"></p>
```
Of course, before displaying this on a page, we are going to sanitize it. So we are using `sanitizeHtml` with the `exclusiveFilter` option to filter out unwanted, empty paragraphs.

```js
const sanitized = sanitizeHtml(raw, {
  exclusiveFilter: (frame) => frame.tag === 'p' && !frame.text.trim()
})
```

Unfortunately, this also strips away the paragraph containing the image.
```html
<p>Here, have this beautiful image:</p>

```
We are stripping paragraphs without text, which makes sense. But we would also love to have a way to tell whether a `<p>` contains something else meaningful, such as an image, to avoid stripping it.

The included test recreates the problematic situation.

Thanks a lot for this wonderful library, we use it extensively.