### PR TITLE
Adds mediaChildren property to frames for filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,10 +301,11 @@ sanitizeHtml(
 
 The `frame` object supplied to the callback provides the following attributes:
 
- - `tag`: The tag name, i.e. `'img'`.
- - `attribs`: The tag's attributes, i.e. `{ src: "/path/to/tux.png" }`.
- - `text`: The text content of the tag.
- - `tagPosition`: The index of the tag's position in the result string.
+- `tag`: The tag name, i.e. `'img'`.
+- `attribs`: The tag's attributes, i.e. `{ src: "/path/to/tux.png" }`.
+- `text`: The text content of the tag.
+- `mediaChildren`: Immediate child tags that are likely to represent self-contained media (e.g., `img`, `video`, `picture`, `iframe`). See the `mediaTags` variable in `src/index.js` for the full list.
+- `tagPosition`: The index of the tag's position in the result string.
 
 You can also process all text content with a provided filter function. Let's say we want an ellipsis instead of three dots.
 

--- a/test/test.js
+++ b/test/test.js
@@ -249,6 +249,25 @@ describe('sanitizeHtml', function() {
       ''
     );
   });
+
+  it('Should find child media elements that are in allowedTags', function() {
+    var markup = '<a href="http://www.linux.org"><img /><video></video></a>';
+    var sansVideo = '<a href="http://www.linux.org"><img /></a>';
+    var sanitizedMarkup = sanitizeHtml(markup, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+      exclusiveFilter: function(frame) {
+        if (frame.tag === 'a') {
+          console.log(frame);
+          assert(frame.mediaChildren.length === 1);
+        }
+
+        return (frame.tag === 'a') && !frame.text.trim() && !frame.mediaChildren.length;
+      }
+    });
+
+    assert.strictEqual(sanitizedMarkup, sansVideo);
+  });
+
   it('Exclusive filter should not affect elements which do not match the filter condition', function () {
     assert.strictEqual(
       sanitizeHtml('I love <a href="www.linux.org" target="_hplink">Linux</a> OS',


### PR DESCRIPTION
Based on #108 . Closes #313 

This will allow devs to check for media elements so elements can be maintained even if there is no text inside them. Previous discussions have revolved around self-closing tags (or "[void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements)", T.I.L.), but not all self-closing tags meet the use cases described (e.g., `hr`, `br`). By specifically checking for media elements, we can meet the use cases described -- primarily link anchor tags with images inside being collapsed.