### PR TITLE
Fix srcset parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "chalk": "^2.4.1",
     "htmlparser2": "^4.1.0",
     "lodash": "^4.17.15",
+    "parse-srcset": "^1.0.2",
     "postcss": "^7.0.27",
-    "srcset": "^2.0.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -703,6 +703,15 @@ describe('sanitizeHtml', function() {
       '<img src="fallback.jpg" srcset="foo.jpg 100w, bar.jpg 200w" />'
     );
   });
+  it('should accept srcset with urls containing commas', function() {
+    assert.equal(
+      sanitizeHtml('<img src="fallback.jpg" srcset="/upload/f_auto,q_auto:eco,c_fit,w_1460,h_2191/abc.jpg 1460w, /upload/f_auto,q_auto:eco,c_fit,w_1360,h_2041/abc.jpg" />', {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
+        allowedAttributes: { img: [ 'src', 'srcset' ] }
+      }),
+      '<img src="fallback.jpg" srcset="/upload/f_auto,q_auto:eco,c_fit,w_1460,h_2191/abc.jpg 1460w, /upload/f_auto,q_auto:eco,c_fit,w_1360,h_2041/abc.jpg" />'
+    );
+  });
   it('drop attribute names with meta-characters', function() {
     assert.equal(
       sanitizeHtml('<span data-<script>alert(1)//>', {

--- a/test/test.js
+++ b/test/test.js
@@ -687,20 +687,20 @@ describe('sanitizeHtml', function() {
   });
   it('should accept srcset if allowed', function() {
     assert.equal(
-      sanitizeHtml('<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />', {
+      sanitizeHtml('<img src="fallback.jpg" srcset="foo.jpg 100w, bar.jpg 200w" />', {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
         allowedAttributes: { img: [ 'src', 'srcset' ] }
       }),
-      '<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />'
+      '<img src="fallback.jpg" srcset="foo.jpg 100w, bar.jpg 200w" />'
     );
   });
   it('should drop bogus srcset', function() {
     assert.equal(
-      sanitizeHtml('<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x, javascript:alert(1) 100w 2x" />', {
+      sanitizeHtml('<img src="fallback.jpg" srcset="foo.jpg 100w, bar.jpg 200w, javascript:alert(1) 100w" />', {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
         allowedAttributes: { img: [ 'src', 'srcset' ] }
       }),
-      '<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />'
+      '<img src="fallback.jpg" srcset="foo.jpg 100w, bar.jpg 200w" />'
     );
   });
   it('drop attribute names with meta-characters', function() {


### PR DESCRIPTION
Replace [srcset](https://github.com/sindresorhus/srcset) with [parse-srcset](https://github.com/albell/parse-srcset) to address https://github.com/apostrophecms/sanitize-html/issues/367.

Additionally, fix tests with invalid srcset containing both width descriptor and pixel density descriptor. [Only zero or one of those is allowed](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes).