### PR TITLE
Replace lodash with small packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 1.27.1 (2020-07-15):
 - Removes the unused chalk dependency.
 - Adds configuration for a Github stale bot.
+- Replace `xtend` package with native `Object.assign`.
 
 1.27.0:
 - Adds the `allowedIframeDomains` option. This works similar to `allowedIframeHostnames`, where you would set it to an array of web domains. It would then permit any hostname on those domains to be used in iframe `src` attributes. Thanks to [Stanislav Kravchenko](https://github.com/StanisLove) for the contribution.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
   "author": "Apostrophe Technologies, Inc.",
   "license": "MIT",
   "dependencies": {
+    "deepmerge": "^4.2.2",
+    "escape-string-regexp": "^4.0.0",
     "htmlparser2": "^4.1.0",
-    "lodash": "^4.17.15",
+    "is-plain-object": "^3.0.1",
+    "klona": "^1.1.2",
     "postcss": "^7.0.27",
     "srcset": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "htmlparser2": "^4.1.0",
     "lodash": "^4.17.15",
     "postcss": "^7.0.27",
-    "srcset": "^2.0.1",
-    "xtend": "^4.0.1"
+    "srcset": "^2.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 /* eslint-disable no-useless-escape */
 var htmlparser = require('htmlparser2');
-var quoteRegexp = require('lodash/escapeRegExp');
-var cloneDeep = require('lodash/cloneDeep');
-var mergeWith = require('lodash/mergeWith');
-var isString = require('lodash/isString');
-var isPlainObject = require('lodash/isPlainObject');
+var escapeStringRegexp = require('escape-string-regexp');
+var klona = require('klona');
+var deepmerge = require('deepmerge');
+var isPlainObject = require('is-plain-object');
 var srcset = require('srcset');
 var postcss = require('postcss');
 var url = require('url');
@@ -137,8 +136,8 @@ function sanitizeHtml(html, options, _recursing) {
       allowedAttributesMap[tag] = [];
       var globRegex = [];
       attributes.forEach(function(obj) {
-        if (isString(obj) && obj.indexOf('*') >= 0) {
-          globRegex.push(quoteRegexp(obj).replace(/\\\*/g, '.*'));
+        if (typeof obj === 'string' && obj.indexOf('*') >= 0) {
+          globRegex.push(escapeStringRegexp(obj).replace(/\\\*/g, '.*'));
         } else {
           allowedAttributesMap[tag].push(obj);
         }
@@ -571,20 +570,15 @@ function sanitizeHtml(html, options, _recursing) {
       return abstractSyntaxTree;
     }
 
-    var filteredAST = cloneDeep(abstractSyntaxTree);
+    var filteredAST = klona(abstractSyntaxTree);
     var astRules = abstractSyntaxTree.nodes[0];
     var selectedRule;
 
     // Merge global and tag-specific styles into new AST.
     if (allowedStyles[astRules.selector] && allowedStyles['*']) {
-      selectedRule = mergeWith(
-        cloneDeep(allowedStyles[astRules.selector]),
-        allowedStyles['*'],
-        function(objValue, srcValue) {
-          if (Array.isArray(objValue)) {
-            return objValue.concat(srcValue);
-          }
-        }
+      selectedRule = deepmerge(
+        allowedStyles[astRules.selector],
+        allowedStyles['*']
       );
     } else {
       selectedRule = allowedStyles[astRules.selector] || allowedStyles['*'];

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-useless-escape */
 var htmlparser = require('htmlparser2');
-var extend = require('xtend');
 var quoteRegexp = require('lodash/escapeRegExp');
 var cloneDeep = require('lodash/cloneDeep');
 var mergeWith = require('lodash/mergeWith');
@@ -101,9 +100,9 @@ function sanitizeHtml(html, options, _recursing) {
     options = sanitizeHtml.defaults;
     options.parser = htmlParserDefaults;
   } else {
-    options = extend(sanitizeHtml.defaults, options);
+    options = Object.assign({}, sanitizeHtml.defaults, options);
     if (options.parser) {
-      options.parser = extend(htmlParserDefaults, options.parser);
+      options.parser = Object.assign({}, htmlParserDefaults, options.parser);
     } else {
       options.parser = htmlParserDefaults;
     }


### PR DESCRIPTION
Lodash is quite big project with a lot of code which can be useless for
end user. https://packagephobia.com/result?p=lodash

I suggest to migrate to small popular packages without dependencies.

- `lodash/escapeRegExp` -> `escape-string-regexp` (node v10 is required)
- `lodash/cloneDeep` -> `klona`
- `lodash/mergeWith` -> `deepmerge` (immutable and arrays are concatenated by default)
- `lodash/isString` -> `typeof value === 'string`
- `lodash/isPlainObject` -> `is-plain-object` (no dependencies in latest version)