### PR TITLE
Fix/125

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,6 +208,8 @@ function sanitizeHtml(html, options, _recursing) {
         frame.attribs = attribs = transformedTag.attribs;
 
         if (transformedTag.text !== undefined) {
+          // Text first replaced here. Should this set `skipText` to `true`?
+          // That's probably too simplistic.
           frame.innerText = transformedTag.text;
         }
 
@@ -423,6 +425,7 @@ function sanitizeHtml(html, options, _recursing) {
         if (options.textFilter) {
           result += options.textFilter(escaped, tag);
         } else {
+          // Text duplicated here.
           result += escaped;
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ function sanitizeHtml(html, options, _recursing) {
     var transFun;
     if (typeof transform === 'function') {
       transFun = transform;
-    } else if (typeof transform === "string") {
+    } else if (typeof transform === 'string') {
       transFun = sanitizeHtml.simpleTransform(transform);
     }
     if (tag === '*') {
@@ -307,7 +307,7 @@ function sanitizeHtml(html, options, _recursing) {
                 if (isRelativeUrl) {
                   // default value of allowIframeRelativeUrls is true
                   // unless allowedIframeHostnames or allowedIframeDomains specified
-                  allowed = has(options, "allowIframeRelativeUrls")
+                  allowed = has(options, 'allowIframeRelativeUrls')
                     ? options.allowIframeRelativeUrls
                     : (!options.allowedIframeHostnames && !options.allowedIframeDomains);
                 } else if (options.allowedIframeHostnames || options.allowedIframeDomains) {
@@ -363,7 +363,7 @@ function sanitizeHtml(html, options, _recursing) {
             }
             if (a === 'style') {
               try {
-                var abstractSyntaxTree = postcss.parse(name + " {" + value + "}");
+                var abstractSyntaxTree = postcss.parse(name + ' {' + value + '}');
                 var filteredAST = filterCss(abstractSyntaxTree, options.allowedStyles);
 
                 value = stringifyStyleAttributes(filteredAST);
@@ -387,9 +387,9 @@ function sanitizeHtml(html, options, _recursing) {
         });
       }
       if (options.selfClosing.indexOf(name) !== -1) {
-        result += " />";
+        result += ' />';
       } else {
-        result += ">";
+        result += '>';
         if (frame.innerText && !hasText && !options.textFilter) {
           result += frame.innerText;
         }
@@ -482,7 +482,7 @@ function sanitizeHtml(html, options, _recursing) {
         return;
       }
 
-      result += "</" + name + ">";
+      result += '</' + name + '>';
       if (skip) {
         result = tempResult + escapeHtml(result);
         tempResult = '';

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-var assert = require("assert");
+var assert = require('assert');
 const sinon = require('sinon');
 
 describe('sanitizeHtml', function() {
@@ -241,7 +241,7 @@ describe('sanitizeHtml', function() {
     );
   });
 
-  it("Should expose a node's inner text and inner HTML to the filter", function() {
+  it('Should expose a node\'s inner text and inner HTML to the filter', function() {
     assert.strictEqual(
       sanitizeHtml('<p>12<a href="http://www.linux.org"><br/>3<br></a><span>4</span></p>', {
         exclusiveFilter: function(frame) {
@@ -390,7 +390,7 @@ describe('sanitizeHtml', function() {
   it('should not crash on bad markup', function() {
     assert.equal(
       sanitizeHtml(
-        "<p a"
+        '<p a'
       ),
       ''
     );
@@ -415,7 +415,7 @@ describe('sanitizeHtml', function() {
 
   it('should deliver a warning if using vulnerable tags', function() {
     const spy = sinon.spy(console, 'warn');
-    const message = `\n\n⚠️ Your \`allowedTags\` option includes, \`style\`, which is inherently\nvulnerable to XSS attacks. Please remove it from \`allowedTags\`.\nOr, to disable this warning, add the \`allowVulnerableTags\` option\nand ensure you are accounting for this risk.\n\n`;
+    const message = '\n\n⚠️ Your `allowedTags` option includes, `style`, which is inherently\nvulnerable to XSS attacks. Please remove it from `allowedTags`.\nOr, to disable this warning, add the `allowVulnerableTags` option\nand ensure you are accounting for this risk.\n\n';
 
     sanitizeHtml(
       '<style></style>',
@@ -618,27 +618,27 @@ describe('sanitizeHtml', function() {
   });
   it('should respect htmlparser2 options when passed in', function() {
     assert.equal(
-      sanitizeHtml("<Archer><Sterling>I am</Sterling></Archer>", {
+      sanitizeHtml('<Archer><Sterling>I am</Sterling></Archer>', {
         allowedTags: false,
         allowedAttributes: false
       }),
-      "<archer><sterling>I am</sterling></archer>"
+      '<archer><sterling>I am</sterling></archer>'
     );
     assert.equal(
-      sanitizeHtml("<Archer><Sterling>I am</Sterling></Archer>", {
+      sanitizeHtml('<Archer><Sterling>I am</Sterling></Archer>', {
         allowedTags: false,
         allowedAttributes: false,
         parser: {
           lowerCaseTags: false
         }
       }),
-      "<Archer><Sterling>I am</Sterling></Archer>"
+      '<Archer><Sterling>I am</Sterling></Archer>'
     );
   });
   it('should not crash due to tag names that are properties of the universal Object prototype', function() {
     assert.equal(
-      sanitizeHtml("!<__proto__>!"),
-      "!!");
+      sanitizeHtml('!<__proto__>!'),
+      '!!');
   });
   it('should correctly maintain escaping when allowing a nonTextTags tag other than script or style', function() {
     assert.equal(
@@ -719,10 +719,10 @@ describe('sanitizeHtml', function() {
       sanitizeHtml(sanitizeString, {
         allowedTags: false,
         allowedAttributes: {
-          '*': ["dir"],
-          p: ["dir", "style"],
-          li: ["style"],
-          span: ["style"]
+          '*': ['dir'],
+          p: ['dir', 'style'],
+          li: ['style'],
+          span: ['style']
         },
         allowedStyles: {
           '*': {
@@ -737,24 +737,24 @@ describe('sanitizeHtml', function() {
   });
   it('Should remove empty style tags', function() {
     assert.equal(
-      sanitizeHtml("<span style=''></span>", {
+      sanitizeHtml('<span style=\'\'></span>', {
         allowedTags: false,
         allowedAttributes: false
       }),
-      "<span></span>"
+      '<span></span>'
     );
   });
   it('Should remote invalid styles', function() {
     assert.equal(
-      sanitizeHtml("<span style='color: blue; text-align: justify'></span>", {
+      sanitizeHtml('<span style=\'color: blue; text-align: justify\'></span>', {
         allowedTags: false,
         allowedAttributes: {
-          "span": ["style"]
+          'span': ['style']
         },
         allowedStyles: {
           'span': {
-            "color": [/blue/],
-            "text-align": [/left/]
+            'color': [/blue/],
+            'text-align': [/left/]
           }
         }
       }), '<span style="color:blue"></span>'
@@ -762,19 +762,19 @@ describe('sanitizeHtml', function() {
   });
   it('Should allow a specific style from global', function() {
     assert.equal(
-      sanitizeHtml("<span style='color: yellow; text-align: center; font-family: helvetica'></span>", {
+      sanitizeHtml('<span style=\'color: yellow; text-align: center; font-family: helvetica\'></span>', {
         allowedTags: false,
         allowedAttributes: {
-          "span": ["style"]
+          'span': ['style']
         },
         allowedStyles: {
           '*': {
-            "color": [/yellow/],
-            "text-align": [/center/]
+            'color': [/yellow/],
+            'text-align': [/center/]
           },
           'span': {
-            "color": [/green/],
-            "font-family": [/helvetica/]
+            'color': [/green/],
+            'font-family': [/helvetica/]
           }
         }
       }), '<span style="color:yellow;text-align:center;font-family:helvetica"></span>'

--- a/test/test.js
+++ b/test/test.js
@@ -217,6 +217,20 @@ describe('sanitizeHtml', function() {
     }), '<a href="http://somelink">some new text</a>');
   });
 
+  it('should not duplicate transform tag text when textFilter is not set', function () {
+    assert.equal(sanitizeHtml('<a href="http://somelink">some text</a>', {
+      transformTags: {
+        a: function (tagName, attribs) {
+          return {
+            tagName: tagName,
+            attribs: attribs,
+            text: 'some other text'
+          };
+        }
+      }
+    }), '<a href="http://somelink">some other text</a>');
+  });
+
   it('should preserve text when initially set and replace attributes when they are changed by transforming function', function () {
     assert.equal(sanitizeHtml('<a href="http://somelink">some initial text</a>', {
       transformTags: {


### PR DESCRIPTION
Failing test for #125 and #136 

A `text` value in a `transformTags` function is added twice. Once in `onopentag` and again in `ontext`.