### PR TITLE
Upgrade is-plain-object

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deepmerge": "^4.2.2",
     "escape-string-regexp": "^4.0.0",
     "htmlparser2": "^4.1.0",
-    "is-plain-object": "^3.0.1",
+    "is-plain-object": "^4.1.1",
     "klona": "^1.1.2",
     "postcss": "^7.0.27",
     "srcset": "^2.0.1"


### PR DESCRIPTION
Ref https://github.com/jonschlinkert/is-plain-object/releases/tag/v4.0.0

The new version behaves closer to lodash/isPlainObject by considering
`Object.create(null)` as plain object.