### PR TITLE
[v2] Upgrade klona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+- Upgrade `klona` package.
+
 2.0.0-beta.2:
 - Add `files` to `package.json` to prevent publishing unnecessary files to npm #392. Thanks to [styfle](https://github.com/styfle) for the contribution.
 - Removes `iframe` and `nl` from default allowed tags. Adds most innocuous tags to the default `allowedTags` array.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const htmlparser = require('htmlparser2');
 const escapeStringRegexp = require('escape-string-regexp');
-const klona = require('klona');
+const { klona } = require('klona');
 const deepmerge = require('deepmerge');
 const isPlainObject = require('is-plain-object');
 const srcset = require('srcset');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "escape-string-regexp": "^4.0.0",
     "htmlparser2": "^4.1.0",
     "is-plain-object": "^4.1.1",
-    "klona": "^1.1.2",
+    "klona": "^2.0.3",
     "postcss": "^7.0.27",
     "srcset": "^3.0.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -790,7 +790,7 @@ describe('sanitizeHtml', function() {
       '<span></span>'
     );
   });
-  it('Should remote invalid styles', function() {
+  it('Should remove invalid styles', function() {
     assert.equal(
       sanitizeHtml('<span style=\'color: blue; text-align: justify\'></span>', {
         allowedTags: false,


### PR DESCRIPTION
Ref https://github.com/lukeed/klona/releases/tag/v2.0.0

The new version got a few new modes and migrated to named export.