### PR TITLE
Update default allowedTags in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,15 @@ Boom!
 ### Default options
 
 ```js
-allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
-  'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'abbr', 'code', 'hr', 'br', 'div',
-  'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe' ],
+allowedTags: [
+  "address", "article", "aside", "footer", "header", "h1", "h2", "h3", "h4",
+  "h5", "h6", "hgroup", "main", "nav", "section", "blockquote", "dd", "div",
+  "dl", "dt", "figcaption", "figure", "hr", "li", "main", "ol", "p", "pre",
+  "ul", "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn",
+  "em", "i", "kbd", "mark", "q", "rb", "rp", "rt", "rtc", "ruby", "s", "samp",
+  "small", "span", "strong", "sub", "time", "u", "var", "wbr", "caption", "col",
+  "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr"
+],
 disallowedTagsMode: 'discard',
 allowedAttributes: {
   a: [ 'href', 'name', 'target' ],


### PR DESCRIPTION
In v2, `defaults.allowedTags` has been updated. Unfortunately the README.md contains an out-of-date version of the `allowedTags` config variable.

This PR updates the README.md with the current `defaults.allowedTags` value.