### PR TITLE
Allow superscript tag by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0 (2020-09-30):
+- `sup` added to the default allowed tags list. Thanks to [Julian Lam](https://github.com/julianlam) for the contribution.
+
 ## 2.0.0 (2020-09-23):
 - `nestingLimit` option added.
 - Updates ESLint config package and fixes warnings.

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ allowedTags: [
   "dl", "dt", "figcaption", "figure", "hr", "li", "main", "ol", "p", "pre",
   "ul", "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn",
   "em", "i", "kbd", "mark", "q", "rb", "rp", "rt", "rtc", "ruby", "s", "samp",
-  "small", "span", "strong", "sub", "time", "u", "var", "wbr", "caption", "col",
-  "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr"
+  "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr", "caption",
+  "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr"
 ],
 disallowedTagsMode: 'discard',
 allowedAttributes: {

--- a/index.js
+++ b/index.js
@@ -688,7 +688,7 @@ sanitizeHtml.defaults = {
     'a', 'abbr', 'b', 'bdi', 'bdo', 'br', 'cite', 'code', 'data', 'dfn',
     'em', 'i', 'kbd', 'mark', 'q',
     'rb', 'rp', 'rt', 'rtc', 'ruby',
-    's', 'samp', 'small', 'span', 'strong', 'sub', 'time', 'u', 'var', 'wbr',
+    's', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'time', 'u', 'var', 'wbr',
     // Table content
     'caption', 'col', 'colgroup', 'table', 'tbody', 'td', 'tfoot', 'th',
     'thead', 'tr'


### PR DESCRIPTION
It seems subscript (`<sub>`) is allowed, but `<sup>` is not, so this commit adds `sup` to the list of default allowedTags