### PR TITLE
Change use of Array `includes` to `indexOf` for IE11 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function sanitizeHtml(html, options, _recursing) {
     };
 
     this.updateParentNodeMediaChildren = function() {
-      if (stack.length && mediaTags.includes(this.tag)) {
+      if (stack.length && mediaTags.indexOf(this.tag) > -1) {
         const parentFrame = stack[stack.length - 1];
         parentFrame.mediaChildren.push(this.tag);
       }


### PR DESCRIPTION
The use of `includes` in `updateParentNodeMediaChildren` breaks compatibility with IE11, as it was not introduced until ES2016. This simple change uses the perf-equivalent `indexOf` method instead.