### PR TITLE
docs: tweak code language in README for JS imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm install sanitize-html
 
 Import the module:
 
-```bash
+```js
 // In ES modules
 import sanitizeHtml from 'sanitize-html';
 


### PR DESCRIPTION
Super minor fix to the README to set the language on the JS imports for better rendering.

Before:
![](https://up.jross.me/n9l724kd)

After:
![](https://up.jross.me/4166bs5h)