### PR TITLE
Allow script tags for specific domains / hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.4:
+
+- New `allowedScriptHostnames` option, it enables you to specify which hostnames are allowed in a script tag
+- New `allowedScriptDomains` option, it enables you to specify which domains are allowed in a script tag
+
 ## 2.3.3 (2021-03-19):
 - Security fix: `allowedSchemes` and related options did not properly block schemes containing a hyphen, plus sign, period or digit, such as `ms-calculator:`. Thanks to Lukas Euler for pointing out the issue.
 - Added a security note about the known risks associated with using the `parser` option, especially `decodeEntities: false`. See the documentation.

--- a/README.md
+++ b/README.md
@@ -502,6 +502,21 @@ const clean = sanitizeHtml('<p><iframe src="https://us02web.zoom.us/embed/12345"
 });
 ```
 
+### Script Filters
+
+Similarly to iframes you can allow a script tag on a list of whitelisted domains or hostnames
+
+```js
+const clean = sanitizeHtml('<script src="https://www.safe.authorized.com/lib.js"></script>', {
+    allowedTags: ['script'],
+    allowedAttributes: {
+        script: ['src']
+    },
+    allowedScriptHostnames: ['www.authorized.com'],
+    allowedScriptDomains: ['authorized.com'],
+})
+```
+
 ### Allowed URL schemes
 
 By default, we allow the following URL schemes in cases where `href`, `src`, etc. are allowed:

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ const clean = sanitizeHtml('<p><iframe src="https://us02web.zoom.us/embed/12345"
 
 ### Script Filters
 
-Similarly to iframes you can allow a script tag on a list of whitelisted domains or hostnames
+Similarly to iframes you can allow a script tag on a list of whitelisted domains
 
 ```js
 const clean = sanitizeHtml('<script src="https://www.safe.authorized.com/lib.js"></script>', {
@@ -526,8 +526,19 @@ const clean = sanitizeHtml('<script src="https://www.safe.authorized.com/lib.js"
     allowedAttributes: {
         script: ['src']
     },
-    allowedScriptHostnames: ['www.authorized.com'],
     allowedScriptDomains: ['authorized.com'],
+})
+```
+
+You can allow a script tag on a list of whitelisted hostnames too
+
+```js
+const clean = sanitizeHtml('<script src="https://www.authorized.com/lib.js"></script>', {
+    allowedTags: ['script'],
+    allowedAttributes: {
+        script: ['src']
+    },
+    allowedScriptHostnames: [ 'www.authorized.com' ],
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -301,6 +301,28 @@ function sanitizeHtml(html, options, _recursing) {
                 return;
               }
             }
+            if (name === 'script' && a === 'src') {
+              let allowed = true;
+
+              frame.innerText = '';
+
+              const parsed = new URL(value);
+
+              if (options.allowedScriptHostnames || options.allowedScriptDomains) {
+                const allowedHostname = (options.allowedScriptHostnames || []).find(function (hostname) {
+                  return hostname === parsed.hostname;
+                });
+                const allowedDomain = (options.allowedScriptDomains || []).find(function(domain) {
+                  return parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`);
+                });
+                allowed = allowedHostname || allowedDomain;
+              }
+              if (!allowed) {
+                delete frame.attribs[a];
+                return;
+              }
+            }
+
             if (name === 'iframe' && a === 'src') {
               let allowed = true;
               try {

--- a/index.js
+++ b/index.js
@@ -320,17 +320,22 @@ function sanitizeHtml(html, options, _recursing) {
 
               frame.innerText = '';
 
-              const parsed = new URL(value);
+              try {
+                const parsed = new URL(value);
 
-              if (options.allowedScriptHostnames || options.allowedScriptDomains) {
-                const allowedHostname = (options.allowedScriptHostnames || []).find(function (hostname) {
-                  return hostname === parsed.hostname;
-                });
-                const allowedDomain = (options.allowedScriptDomains || []).find(function(domain) {
-                  return parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`);
-                });
-                allowed = allowedHostname || allowedDomain;
+                if (options.allowedScriptHostnames || options.allowedScriptDomains) {
+                  const allowedHostname = (options.allowedScriptHostnames || []).find(function (hostname) {
+                    return hostname === parsed.hostname;
+                  });
+                  const allowedDomain = (options.allowedScriptDomains || []).find(function(domain) {
+                    return parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`);
+                  });
+                  allowed = allowedHostname || allowedDomain;
+                }
+              } catch (e) {
+                allowed = false;
               }
+
               if (!allowed) {
                 delete frame.attribs[a];
                 return;

--- a/test/test.js
+++ b/test/test.js
@@ -903,6 +903,16 @@ describe('sanitizeHtml', function() {
       allowedScriptHostnames: [ 'www.authorized.com' ]
     }), '<script></script>');
   });
+  it('should delete the script tag since src is not a valid URL', function() {
+    assert.equal(sanitizeHtml('<script src="not-a-valid-url"></script>', {
+      allowedTags: [ 'script' ],
+      allowVulnerableTags: true,
+      allowedAttributes: {
+        script: [ 'src' ]
+      },
+      allowedScriptHostnames: [ 'www.unauthorized.com' ]
+    }), '<script></script>');
+  });
   it('Should allow domains in a script that are whitelisted', function() {
     assert.equal(
       sanitizeHtml('<script src="https://www.safe.authorized.com/lib.js"></script>', {

--- a/test/test.js
+++ b/test/test.js
@@ -864,6 +864,47 @@ describe('sanitizeHtml', function() {
       }), '<span style="color:yellow;text-align:center;font-family:helvetica"></span>'
     );
   });
+  it('should delete the script tag', function() {
+    assert.equal(sanitizeHtml('<script src="https://www.unauthorized.com/lib.js"></script>', {
+      allowedTags: [ 'script' ],
+      allowVulnerableTags: true,
+      allowedAttributes: {
+        script: [ 'src' ]
+      },
+      allowedScriptHostnames: [ 'www.authorized.com' ]
+    }), '<script></script>');
+  });
+  it('Should allow domains in a script that are whitelisted', function() {
+    assert.equal(
+      sanitizeHtml('<script src="https://www.safe.authorized.com/lib.js"></script>', {
+        allowedTags: [ 'script' ],
+        allowedAttributes: {
+          script: [ 'src' ]
+        },
+        allowedScriptDomains: [ 'authorized.com' ]
+      }), '<script src="https://www.safe.authorized.com/lib.js"></script>'
+    );
+  });
+  it('should delete the script tag content', function() {
+    assert.equal(sanitizeHtml('<script src="https://www.authorized.com/lib.js"> alert("evil") </script>', {
+      allowedTags: [ 'script' ],
+      allowVulnerableTags: true,
+      allowedAttributes: {
+        script: [ 'src' ]
+      },
+      allowedScriptHostnames: [ 'www.authorized.com' ]
+    }), '<script src="https://www.authorized.com/lib.js"></script>');
+  });
+  it('should leave the content of script elements', function() {
+    assert.equal(sanitizeHtml('<script src="https://www.authorized.com/lib.js"></script>', {
+      allowedTags: [ 'script' ],
+      allowVulnerableTags: true,
+      allowedAttributes: {
+        script: [ 'src' ]
+      },
+      allowedScriptHostnames: [ 'www.authorized.com' ]
+    }), '<script src="https://www.authorized.com/lib.js"></script>');
+  });
   it('Should allow hostnames in an iframe that are whitelisted', function() {
     assert.equal(
       sanitizeHtml('<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>', {

--- a/test/test.js
+++ b/test/test.js
@@ -934,7 +934,7 @@ describe('sanitizeHtml', function() {
       allowedScriptHostnames: [ 'www.authorized.com' ]
     }), '<script src="https://www.authorized.com/lib.js"></script>');
   });
-  it('should leave the content of script elements', function() {
+  it('Should allow hostnames in a script that are whitelisted', function() {
     assert.equal(sanitizeHtml('<script src="https://www.authorized.com/lib.js"></script>', {
       allowedTags: [ 'script' ],
       allowVulnerableTags: true,


### PR DESCRIPTION
I needed the same feature stated here: https://github.com/apostrophecms/sanitize-html/issues/405

Added allowedScriptHostnames and allowedScriptDomains