### PR TITLE
Fix #486: Return an empty string when input is a nullish HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.2:
+- Nullish HTML input now returns an empty string. Nullish value may be explicit `null`, `undefined` or implicit `undefined` when value is not provided.
+
 ## 2.5.1 (2021-09-14):
 - The `allowedScriptHostnames` and `allowedScriptDomains` options now implicitly purge the inline content of all script tags, not just those with `src` attributes. This behavior was already strongly implied by the fact that they purged it in the case where a `src` attribute was actually present, and is necessary for the feature to provide any real security. Thanks to Grigorii Duca for pointing out the issue.
 

--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ const VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
 // https://github.com/fb55/htmlparser2/issues/105
 
 function sanitizeHtml(html, options, _recursing) {
+  if (!html) {
+    return '';
+  }
+
   let result = '';
   // Used for hot swapping the result variable with an empty string in order to "capture" the text written to it.
   let tempResult = '';

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
 // https://github.com/fb55/htmlparser2/issues/105
 
 function sanitizeHtml(html, options, _recursing) {
-  if (!html) {
+  if (html == null) {
     return '';
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,18 @@ describe('sanitizeHtml', function() {
   it('should respect text nodes at top level', function() {
     assert.equal(sanitizeHtml('Blah blah blah<p>Whee!</p>'), 'Blah blah blah<p>Whee!</p>');
   });
+  it('should return an empty string when input is explicit "undefined"', function() {
+    assert.equal(sanitizeHtml(undefined), '');
+  });
+  it('should return an empty string when input is explicit "null"', function() {
+    assert.equal(sanitizeHtml(null), '');
+  });
+  it('should return an empty string when input is not provided', function() {
+    assert.equal(sanitizeHtml(), '');
+  });
+  it('should return an empty string when input is an empty string', function() {
+    assert.equal(sanitizeHtml(''), '');
+  });
   it('should reject markup not allowlisted without destroying its text', function() {
     assert.equal(sanitizeHtml('<div><wiggly>Hello</wiggly></div>'), '<div>Hello</div>');
   });


### PR DESCRIPTION
Note that nullish values also include 0, but according to [this comment](https://github.com/apostrophecms/sanitize-html/pull/102#issuecomment-872242667) of a repo member: 
> In any case it is up to the caller to pass a string.