### PR TITLE
allowedClasses support for regex expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,15 @@ allowedClasses: {
 }
 ```
 
+Furthermore, regex expressions are supported via strings that start with `^` and end with `$`:
+```js
+allowedClasses: {
+  p: [ '^regex\\d{2}$' ]
+}
+```
+
+The above example whitelist all classes that matches this regex: `RegExp('^regex\\d{2}$')`.
+
 ### Allowed CSS Styles
 
 If you wish to allow specific CSS _styles_ on a particular element, you can do that with the `allowedStyles` option. Simply declare your desired attributes as regular expression options within an array for the given attribute. Specific elements will inherit allowlisted attributes from the global (`*`) attribute. Any other CSS classes are discarded.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ const clean = sanitizeHtml(dirty, {
 ```
 
 Similar to `allowedAttributes`, you can use `*` to allow classes with a certain prefix, or use `*` as a tag name to allow listed classes to be valid for any tag:
+
 ```js
 allowedClasses: {
   'code': [ 'language-*', 'lang-*' ],
@@ -246,14 +247,13 @@ allowedClasses: {
 }
 ```
 
-Furthermore, regex expressions are supported via strings that start with `^` and end with `$`:
+Furthermore, regular expressions are supported too and **they must begin with `^` and end with `$`** otherwise the regex has no effect:
+
 ```js
 allowedClasses: {
-  p: [ '^regex\\d{2}$' ]
+  p: [ /^regex\d{2}$/ ]
 }
 ```
-
-The above example whitelist all classes that matches this regex: `RegExp('^regex\\d{2}$')`.
 
 ### Allowed CSS Styles
 

--- a/README.md
+++ b/README.md
@@ -247,13 +247,15 @@ allowedClasses: {
 }
 ```
 
-Furthermore, regular expressions are supported too and **they must begin with `^` and end with `$`** otherwise the regex has no effect:
+Furthermore, regular expressions are supported too:
 
 ```js
 allowedClasses: {
   p: [ /^regex\d{2}$/ ]
 }
 ```
+
+> Note: It is advised to construct your regular expressions by starting with `^` and ending with `$`, like in the example above. This way you allow **only** the classes you declare and not other potentially harmful matches.
 
 ### Allowed CSS Styles
 

--- a/index.js
+++ b/index.js
@@ -170,10 +170,10 @@ function sanitizeHtml(html, options, _recursing) {
     allowedClassesRegexMap[tag] = [];
     const globRegex = [];
     classes.forEach(function(obj) {
-      if (obj instanceof RegExp) {
-        allowedClassesRegexMap[tag].push(obj);
-      } else if (typeof obj === 'string' && obj.indexOf('*') >= 0) {
+      if (typeof obj === 'string' && obj.indexOf('*') >= 0) {
         globRegex.push(escapeStringRegexp(obj).replace(/\\\*/g, '.*'));
+      } else if (obj instanceof RegExp) {
+        allowedClassesRegexMap[tag].push(obj);
       } else {
         allowedClassesMap[tag].push(obj);
       }

--- a/index.js
+++ b/index.js
@@ -168,7 +168,13 @@ function sanitizeHtml(html, options, _recursing) {
     allowedClassesMap[tag] = [];
     const globRegex = [];
     classes.forEach(function(obj) {
-      if (typeof obj === 'string' && obj.indexOf('*') >= 0) {
+      if (
+        typeof obj === 'string' &&
+        obj.indexOf('^') === 0 &&
+        obj.indexOf('$') === obj.length - 1
+      ) {
+        globRegex.push(obj.slice(1, -1));
+      } else if (typeof obj === 'string' && obj.indexOf('*') >= 0) {
         globRegex.push(escapeStringRegexp(obj).replace(/\\\*/g, '.*'));
       } else {
         allowedClassesMap[tag].push(obj);

--- a/test/test.js
+++ b/test/test.js
@@ -432,11 +432,11 @@ describe('sanitizeHtml', function() {
         {
           allowedTags: [ 'p' ],
           allowedClasses: {
-            p: [ '^nifty\\d{2}$' ]
+            p: [ /^nifty\d{2}$/, /^d\w{4}$/ ]
           }
         }
       ),
-      '<p class="nifty33">whee</p>'
+      '<p class="nifty33 dippy">whee</p>'
     );
   });
   it('should allow defining schemes on a per-tag basis', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -425,6 +425,20 @@ describe('sanitizeHtml', function() {
       '<p class="nifty simple dippy">whee</p>'
     );
   });
+  it('should allow only classes that matches `allowedClasses` regex', function() {
+    assert.equal(
+      sanitizeHtml(
+        '<p class="nifty33 nifty2 dippy">whee</p>',
+        {
+          allowedTags: [ 'p' ],
+          allowedClasses: {
+            p: [ '^nifty\\d{2}$' ]
+          }
+        }
+      ),
+      '<p class="nifty33">whee</p>'
+    );
+  });
   it('should allow defining schemes on a per-tag basis', function() {
     assert.equal(
       sanitizeHtml(


### PR DESCRIPTION
Using wildcard on allowedClasses poses a security risk. Having regex support on classes is a better solution where you can be more explicit with the whitelisting.

Disclaimer: This is a performant way of allowing Regular Expressions on the existing codebase in a couple of lines :)