### PR TITLE
added credit and adjusted README language about regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Support for regular expressions in the `allowedClasses` option. Thanks to [Alex Rantos](https://github.com/alex-rantos).
+
 ## 2.5.3 (2021-11-02):
 
 - Fixed bug introduced by klona 2.0.5, by removing klona entirely.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ allowedClasses: {
 }
 ```
 
-> Note: It is advised to construct your regular expressions by starting with `^` and ending with `$`, like in the example above. This way you allow **only** the classes you declare and not other potentially harmful matches.
+> Note: It is advised that your regular expressions always begin with `^` so that you are requiring a known prefix. A regular expression with neither `^` nor `$` just requires that something appear in the middle.
 
 ### Allowed CSS Styles
 


### PR DESCRIPTION
The original language was written with an environment other than plain HTML in mind — in plain HTML the class attribute is never executable javascript, but a reminder to root the regular expression is still a good idea.