### PR TITLE
Fix #504: fix inconsistent iframe src behavior across browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,12 +375,12 @@ function sanitizeHtml(html, options, _recursing) {
                 //
                 // Build a placeholder "base URL" against which any reasonable
                 // relative URL may be parsed successfully
-                let base = 'relative://relative-site';
+                let base = 'https://relative-site';
                 for (let i = 0; (i < 100); i++) {
                   base += `/${i}`;
                 }
                 const parsed = new URL(value, base);
-                const isRelativeUrl = parsed && parsed.hostname === 'relative-site' && parsed.protocol === 'relative:';
+                const isRelativeUrl = parsed && parsed.hostname === 'relative-site';
                 if (isRelativeUrl) {
                   // default value of allowIframeRelativeUrls is true
                   // unless allowedIframeHostnames or allowedIframeDomains specified


### PR DESCRIPTION
Fix #504 

This solution opts to replace the `relative` protocol of the URL parser's base URL with the special scheme protocol `https`. This does not alter the original value in any way, but retains the ability to determine whether the given URL is relative.