### PR TITLE
Fix trailing text issue on transformTag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Fix trailing text bug on `transformTags` options that was reported on [issue #506](https://github.com/punkave/sanitize-html/issues/506). Thanks to [Alex Rantos](https://github.com/alex-rantos).
+- Fixed trailing text bug on `transformTags` options that was reported on [issue #506](https://github.com/punkave/sanitize-html/issues/506). Thanks to [Alex Rantos](https://github.com/alex-rantos).
 
 ## 2.6.0 (2021-11-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Fix trailing text bug on `transformTags` options that was reported on [issue #506](https://github.com/punkave/sanitize-html/issues/506). Thanks to [Alex Rantos](https://github.com/alex-rantos).
+
 ## 2.6.0 (2021-11-23)
 
 - Support for regular expressions in the `allowedClasses` option. Thanks to [Alex Rantos](https://github.com/alex-rantos).

--- a/index.js
+++ b/index.js
@@ -582,6 +582,7 @@ function sanitizeHtml(html, options, _recursing) {
         result = tempResult + escapeHtml(result);
         tempResult = '';
       }
+      addedText = false;
     }
   }, options.parser);
   parser.write(html);

--- a/test/test.js
+++ b/test/test.js
@@ -228,6 +228,19 @@ describe('sanitizeHtml', function() {
     }), '<a href="http://somelink">some good text</a>');
   });
 
+  it('should preserve trailing text when replacing the tagName and adding new text via transforming function', function () {
+    assert.equal(sanitizeHtml('<p>text before <br> text after</p>', {
+      transformTags: {
+        br: function (_tagName, _attribs) {
+          return {
+            tagName: 'span',
+            text: ' '
+          };
+        }
+      }
+    }), '<p>text before <span> </span> text after</p>');
+  });
+
   it('should add new text when not initially set and replace attributes when they are changed by transforming function', function () {
     assert.equal(sanitizeHtml('<a href="http://somelink"></a>', {
       transformTags: {


### PR DESCRIPTION
Fixes issue #506

Fixes regression caused by https://github.com/apostrophecms/sanitize-html/pull/395 in which `addedText` was never reseted to false after the `ontext` function was called for that tag.

Solution: reset `addedText` boolean to false in the onclosetag function.
