### PR TITLE
feature: do not check case for css properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Added support for not checking the case of CSS properties.
+
 ## 2.6.1 (2021-12-08)
 
 - Fixes style filtering to retain `!important` when used.

--- a/index.js
+++ b/index.js
@@ -722,9 +722,11 @@ function sanitizeHtml(html, options, _recursing) {
     */
   function filterDeclarations(selectedRule) {
     return function (allowedDeclarationsList, attributeObject) {
+      // We don't care about the case of the property (i.e. margin-left vs Margin-left)
+      const attributeProp = attributeObject.prop.toLowerCase();
       // If this property is allowlisted...
-      if (has(selectedRule, attributeObject.prop)) {
-        const matchesRegex = selectedRule[attributeObject.prop].some(function(regularExpression) {
+      if (has(selectedRule, attributeProp)) {
+        const matchesRegex = selectedRule[attributeProp].some(function(regularExpression) {
           return regularExpression.test(attributeObject.value);
         });
 

--- a/test/test.js
+++ b/test/test.js
@@ -864,6 +864,29 @@ describe('sanitizeHtml', function() {
       '<span>alert(1)//&gt;</span>'
     );
   });
+  it('should allow css properties within the style tag no matter the case', function() {
+    const sanitizeString = '<div style="Margin-right: auto; margin-left: auto;">test</div>';
+    const expected = '<div style="Margin-right:auto;margin-left:auto">test</div>';
+    assert.equal(
+      sanitizeHtml(sanitizeString, {
+        allowedTags: false,
+        allowedAttributes: {
+          '*': [ 'dir' ],
+          div: [ 'dir', 'style' ]
+        },
+        allowedStyles: {
+          '*': {
+            // Matches hex
+            color: [ /#(0x)?[0-9a-f]+/i ],
+            'text-align': [ /left/, /right/, /center/, /justify/, /initial/, /inherit/ ],
+            'font-size': [ /36px/ ],
+            'margin-right': [ /auto/ ],
+            'margin-left': [ /auto/ ]
+          }
+        }
+      }).replace(/ /g, ''), expected.replace(/ /g, '')
+    );
+  });
   it('should sanitize styles correctly', function() {
     const sanitizeString = '<p dir="ltr"><strong>beste</strong><em>testestes</em><s>testestset</s><u>testestest</u></p><ul dir="ltr"> <li><u>test</u></li></ul><blockquote dir="ltr"> <ol> <li><u>test</u></li><li><u>test</u></li><li style="text-align: right"><u>test</u></li><li style="text-align: justify"><u>test</u></li></ol> <p><u><span style="color:#00FF00">test</span></u></p><p><span style="color:#00FF00"><span style="font-size:36px">TESTETESTESTES</span></span></p></blockquote>';
     const expected = '<p dir="ltr"><strong>beste</strong><em>testestes</em><s>testestset</s><u>testestest</u></p><ul dir="ltr"> <li><u>test</u></li></ul><blockquote dir="ltr"> <ol> <li><u>test</u></li><li><u>test</u></li><li style="text-align: right"><u>test</u></li><li style="text-align: justify"><u>test</u></li></ol> <p><u><span style="color:#00FF00">test</span></u></p><p><span style="color:#00FF00"><span style="font-size:36px">TESTETESTESTES</span></span></p></blockquote>';


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

Treats CSS properties case insensitively within filters. Specifically treats: `margin-left: auto` and `Margin-left: auto` as the same thing. Currently there isn't any way to define a whitelist of CSS properties (at least that I can tell). 

I acknowledge that this would likely be a breaking change, so I think I'll need to add a configuration option to enable/disable this check, and I'll need to add the documentation for this too.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

There is a test case for it, but to be specific:

1. Allow the style attribute
2. Define some allowed CSS property (e.g. `margin-left`)
3. Try input with a different casing of `margin-left` (e.g. `Margin-left`)

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves

No open issue from what I can find, but I wanted to raise the issue with a pull request, rather than just create an issue. I do acknowledge that likely the PR in its current state will need some changes (specifically: backwards compatibility/a configuration option). The goal of this is to allow case insensitive filters for allowed properties, so that `MARGIN-LEFT: auto;` would be treated the same as `margin-left: auto;` if the option was enabled.

- [x] The changelog is updated
- [ ] Related documentation has been updated
This hasn't been done, but if we add an option for this, I'll write some documentation about that option.
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Given that there is no open issue for this feature, I'd like to suggest that this be used as a discussion point, with the goal of either: making additional updates if accepted, or closing the PR without anything being merged if what I'm suggesting doesn't match the goals of the repository.