### PR TITLE
Fix auto-adding escaped closing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED (2023-01-31)
+
+- Fix auto-adding escaped closing tags. In other words, do not add implied closing tags to disallowed tags when `disallowedTagMode` is set to any variant of `escape` -- just escape the disallowed tags that are present. This fixes [issue #464](https://github.com/apostrophecms/sanitize-html/issues/464). Thanks to [Daniel Liebner](https://github.com/dliebner)
+- Add `tagAllowed()` helper function which takes a tag name and checks it against `options.allowedTags` and returns `true` if the tag is allowed and `false` if it is not.
+
 ## 2.9.0 (2023-01-27)
 
 - Add option parseStyleAttributes to skip style parsing. This fixes [issue #547](https://github.com/apostrophecms/sanitize-html/issues/547). Thanks to [Bert Verhelst](https://github.com/bertyhell).

--- a/index.js
+++ b/index.js
@@ -566,17 +566,11 @@ function sanitizeHtml(html, options, _recursing) {
       frame.updateParentNodeMediaChildren();
       frame.updateParentNodeText();
 
-      if( name === 'wacky' ) {
-
-        console.log( tagAllowed(name), ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0 );
-
-      }
-
       if (
         // Already output />
         options.selfClosing.indexOf(name) !== -1 ||
         // Escaped tag
-        (tagAllowed(name) || ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0)
+        (!tagAllowed(name) && ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0)
       ) {
         if (skip) {
           result = tempResult;

--- a/index.js
+++ b/index.js
@@ -118,9 +118,7 @@ function sanitizeHtml(html, options, _recursing) {
   options.parser = Object.assign({}, htmlParserDefaults, options.parser);
 
   const tagAllowed = function (name) {
-  
     return options.allowedTags === false || (options.allowedTags || []).indexOf(name) > -1;
-
   };
 
   // vulnerableTags
@@ -516,7 +514,7 @@ function sanitizeHtml(html, options, _recursing) {
         frame.text += text;
       }
     },
-    onclosetag: function(name) {
+    onclosetag: function(name, isImplied) {
 
       if (skipText) {
         skipTextDepth--;
@@ -569,8 +567,8 @@ function sanitizeHtml(html, options, _recursing) {
       if (
         // Already output />
         options.selfClosing.indexOf(name) !== -1 ||
-        // Escaped tag
-        (!tagAllowed(name) && ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0)
+        // Escaped tag, closing tag is implied
+        (isImplied && !tagAllowed(name) && ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0)
       ) {
         if (skip) {
           result = tempResult;

--- a/index.js
+++ b/index.js
@@ -568,7 +568,7 @@ function sanitizeHtml(html, options, _recursing) {
         // Already output />
         options.selfClosing.indexOf(name) !== -1 ||
         // Escaped tag, closing tag is implied
-        (isImplied && !tagAllowed(name) && ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0)
+        (isImplied && !tagAllowed(name) && [ 'escape', 'recursiveEscape' ].indexOf(options.disallowedTagsMode) >= 0)
       ) {
         if (skip) {
           result = tempResult;

--- a/index.js
+++ b/index.js
@@ -566,11 +566,17 @@ function sanitizeHtml(html, options, _recursing) {
       frame.updateParentNodeMediaChildren();
       frame.updateParentNodeText();
 
+      if( name === 'wacky' ) {
+
+        console.log( tagAllowed(name), ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0 );
+
+      }
+
       if (
         // Already output />
         options.selfClosing.indexOf(name) !== -1 ||
         // Escaped tag
-        (tagAllowed(name) || ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) === -1)
+        (tagAllowed(name) || ['escape','recursiveEscape'].indexOf(options.disallowedTagsMode) >= 0)
       ) {
         if (skip) {
           result = tempResult;

--- a/test/test.js
+++ b/test/test.js
@@ -1561,4 +1561,17 @@ describe('sanitizeHtml', function() {
       }), '<script src="//example.com/script.js"></script>'
     );
   });
+  it('should not automatically attach close tag for escaped tags', function() {
+    assert.equal(sanitizeHtml('<test>Hello', {
+      disallowedTagsMode: 'escape',
+    }), '&lt;test&gt;Hello');
+    assert.equal(sanitizeHtml('<test><test><test><test><test>Hello', {
+      disallowedTagsMode: 'recursiveEscape',
+    }), '&lt;test&gt;&lt;test&gt;&lt;test&gt;&lt;test&gt;&lt;test&gt;Hello');
+  });
+  it('should discard unclosed disallowed tags', function() {
+    assert.equal(sanitizeHtml('<test>Hello', {
+      disallowedTagsMode: 'discard',
+    }), 'Hello');
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1561,17 +1561,19 @@ describe('sanitizeHtml', function() {
       }), '<script src="//example.com/script.js"></script>'
     );
   });
-  it('should not automatically attach close tag for escaped tags', function() {
+  it('should not automatically attach close tag for escaped tags in escape mode', function() {
     assert.equal(sanitizeHtml('<test>Hello', {
-      disallowedTagsMode: 'escape',
+      disallowedTagsMode: 'escape'
     }), '&lt;test&gt;Hello');
+  });
+  it('should not automatically attach close tag for escaped tags in recursiveEscape mode', function() {
     assert.equal(sanitizeHtml('<test><test><test><test><test>Hello', {
-      disallowedTagsMode: 'recursiveEscape',
+      disallowedTagsMode: 'recursiveEscape'
     }), '&lt;test&gt;&lt;test&gt;&lt;test&gt;&lt;test&gt;&lt;test&gt;Hello');
   });
   it('should discard unclosed disallowed tags', function() {
     assert.equal(sanitizeHtml('<test>Hello', {
-      disallowedTagsMode: 'discard',
+      disallowedTagsMode: 'discard'
     }), 'Hello');
   });
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Closes #464 
Adds `tagAllowed()` helper function.

## What are the specific steps to test this change?

Existing tests may need to be reviewed. I don't do a lot of PRs, sorry.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
