### PR TITLE
fix: ignore source maps when processing with postcss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Clarified the use of SVGs with a new test and changes to documentation. 
 
+- Do not process source maps when processing style tags with PostCSS.
+
 ## 2.11.0 (2023-06-21)
 
 - Fix to allow `false` in `allowedClasses` attributes. Thanks to [Kevin Jiang](https://github.com/KevinSJ) for this fix!

--- a/index.js
+++ b/index.js
@@ -453,7 +453,7 @@ function sanitizeHtml(html, options, _recursing) {
             if (a === 'style') {
               if (options.parseStyleAttributes) {
                 try {
-                  const abstractSyntaxTree = postcssParse(name + ' {' + value + '}');
+                  const abstractSyntaxTree = postcssParse(name + ' {' + value + '}', { map: false });
                   const filteredAST = filterCss(abstractSyntaxTree, options.allowedStyles);
 
                   value = stringifyStyleAttributes(filteredAST);

--- a/test/test.js
+++ b/test/test.js
@@ -1659,5 +1659,13 @@ describe('sanitizeHtml', function() {
       }
     }), '<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><linearGradient id="myGradient" gradientTransform="rotate(90)"><stop offset="5%" stop-color="gold"></stop><stop offset="95%" stop-color="red"></stop></linearGradient></defs><circle cx="5" cy="5" r="4" fill="url(\'#myGradient\')"></circle></svg>');
   });
+  it('should not process style sourceMappingURL with postCSS', () => {
+    assert.equal(sanitizeHtml('<a style=\'background-image: url("/*# sourceMappingURL=../index.js */");\'></a>', {
+      allowedAttributes: {
+        ...sanitizeHtml.defaults.allowedAttributes,
+        a: [ 'style' ]
+      }
+    }), '<a style="background-image:url(&quot;/*# sourceMappingURL=../index.js */&quot;)"></a>');
+  });
 
 });


### PR DESCRIPTION
## Summary

Do not process source maps when using PostCSS.

## What are the specific steps to test this change?

Test provided in PR.

## What kind of change does this PR introduce?
- [x] Bug fix

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated