### PR TITLE
Add `preserveEscapedAttributes` option to retain all attributes of escaped disallowed tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,15 @@ disallowedTagsMode: `recursiveEscape`
 
 This will transform `<disallowed>hello<p>world</p></disallowed>` to `&lt;disallowed&gt;hello&lt;p&gt;world&lt;/p&gt;&lt;/disallowed&gt;`
 
+#### Escape the disallowed tag, including all its attributes.
+
+By default, disallowed attributes are stripped from escaped tags. You can set `preserveEscapedAttributes` to `true` to 
+keep them as-is.
+
+```js
+preserveEscapedAttributes: true
+```
+
 ### Ignore style attribute contents
 
 Instead of discarding faulty style attributes, you can allow them by disabling the parsing of style attributes:

--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ This will transform `<disallowed>hello<p>world</p></disallowed>` to `&lt;disallo
 #### Escape the disallowed tag, including all its attributes.
 
 By default, disallowed attributes are stripped from escaped tags. You can set `preserveEscapedAttributes` to `true` to 
-keep them as-is.
+keep them as-is. Note that is intended mainly for development or trusted workflows, and may preserve dangerous attributes as escaped text.
 
 ```js
 preserveEscapedAttributes: true

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ This will transform `<disallowed>content <allowed>content</allowed> </disallowed
 
 #### Escape the disallowed tag and all its children even for allowed tags.
 
-if you set `disallowedTagsMode` to `recursiveEscape`, disallowed tag and its children will be escaped even for allowed tags
+if you set `disallowedTagsMode` to `recursiveEscape`, disallowed tags and their children will be escaped even for allowed tags:
 
 ```js
 disallowedTagsMode: `recursiveEscape`
@@ -755,8 +755,8 @@ This will transform `<disallowed>hello<p>world</p></disallowed>` to `&lt;disallo
 
 #### Escape the disallowed tag, including all its attributes.
 
-By default, disallowed attributes are stripped from escaped tags. You can set `preserveEscapedAttributes` to `true` to 
-keep them as-is. Note that is intended mainly for development or trusted workflows, and may preserve dangerous attributes as escaped text.
+By default, attributes are not preserved when tags are escaped. You can set `preserveEscapedAttributes` to `true` to 
+keep the attributes, which will also be escaped and therefore have no effect on the browser.
 
 ```js
 preserveEscapedAttributes: true

--- a/index.js
+++ b/index.js
@@ -300,7 +300,14 @@ function sanitizeHtml(html, options, _recursing) {
         }
       }
 
-      if (!allowedAttributesMap || has(allowedAttributesMap, name) || allowedAttributesMap['*']) {
+      const isBeingEscaped = skip && (options.disallowedTagsMode === 'escape' || options.disallowedTagsMode === 'recursiveEscape');
+      const shouldPreserveEscapedAttributes = isBeingEscaped && options.preserveEscapedAttributes;
+
+      if (shouldPreserveEscapedAttributes) {
+        each(attribs, function(value, a) {
+          result += ' ' + a + '="' + escapeHtml((value || ''), true) + '"';
+        });
+      } else if (!allowedAttributesMap || has(allowedAttributesMap, name) || allowedAttributesMap['*']) {
         each(attribs, function(value, a) {
           if (!VALID_HTML_ATTRIBUTE_NAME.test(a)) {
             // This prevents part of an attribute name in the output from being
@@ -923,7 +930,8 @@ sanitizeHtml.defaults = {
   allowedSchemesAppliedToAttributes: [ 'href', 'src', 'cite' ],
   allowProtocolRelative: true,
   enforceHtmlBoundary: false,
-  parseStyleAttributes: true
+  parseStyleAttributes: true,
+  preserveEscapedAttributes: false
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/test/test.js
+++ b/test/test.js
@@ -1833,4 +1833,19 @@ describe('sanitizeHtml', function() {
 
     assert.equal(sanitizedHtml, expectedOutput);
   });
+  it('should ignore the `preserveEscapedAttributes` option when discarding diallowed tags (rather than escaping)', () => {
+    const inputHtml = '<div class="foo">Some Text</div>';
+    const sanitizedHtmlPreservedAttrsTrue = sanitizeHtml(inputHtml, {
+      allowedTags: [],
+      disallowedTagsMode: 'discard',
+      preserveEscapedAttributes: true
+    });
+    const sanitizedHtmlPreservedAttrsFalse = sanitizeHtml(inputHtml, {
+      allowedTags: [],
+      disallowedTagsMode: 'discard',
+      preserveEscapedAttributes: false
+    });
+
+    assert.equal(sanitizedHtmlPreservedAttrsTrue, sanitizedHtmlPreservedAttrsFalse);
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1811,4 +1811,26 @@ describe('sanitizeHtml', function() {
     );
     assert.equal(sanitizedHtml, expectedOutput);
   });
+  it('should not preserve attributes on escaped disallowed tags when `preserveEscapedAttributes` is false', () => {
+    const inputHtml = '<div class="foo">Some Text</div>';
+    const expectedOutput = '&lt;div&gt;Some Text&lt;/div&gt;';
+    const sanitizedHtml = sanitizeHtml(inputHtml, {
+      allowedTags: [],
+      disallowedTagsMode: 'escape',
+      preserveEscapedAttributes: false
+    });
+
+    assert.equal(sanitizedHtml, expectedOutput);
+  });
+  it('should preserve attributes on escaped disallowed tags when `preserveEscapedAttributes` is true', () => {
+    const inputHtml = '<div class="foo">Some Text</div>';
+    const expectedOutput = '&lt;div class="foo"&gt;Some Text&lt;/div&gt;';
+    const sanitizedHtml = sanitizeHtml(inputHtml, {
+      allowedTags: [],
+      disallowedTagsMode: 'escape',
+      preserveEscapedAttributes: true
+    });
+
+    assert.equal(sanitizedHtml, expectedOutput);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/apostrophecms/sanitize-html/issues/540

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*

Add `preserveEscapedAttributes` option to allow attributes on escaped disallowed tags to be retained. Closes #540 

## What are the specific steps to test this change?

You can try the new behaviour by setting `preserveEscapedAttributes` to `true` when `disallowedTagsMode` is `'escape'` or `'recursiveEscape'`.

Added unit tests to PR. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
