### PR TITLE
feat: add tag open, tag close, and text events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Add `onOpenTag` and `onCloseTag` events to enable advanced filtering to hook into the parser.
+
 ## 2.14.0 (2024-12-18)
 
 - Fix adding text with `transformTags` in cases where it originally had no text child elements. Thanks to [f0x](https://cthu.lu).

--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ const sanitizedHtml = sanitizeHtml(
 );
 ```
 
-In this example we are tracking when a removed tag has opened or closed and modify text that follows it. The example should produce:
+In this example, we are setting a flag when a tag that will be removed has been opened or closed. Then we use the `textFilter` to modify the text to include spaces. The example should produce:
 ```
 Text's here it's here it's there and <b>also</b> here.
 ```

--- a/README.md
+++ b/README.md
@@ -786,11 +786,11 @@ const sanitizedHtml = sanitizeHtml(
   'There should be<div><p>spaces</p></div>between <b>these</b> words.',
   {
     allowedTags,
-    onOpenTag: (tag) => {
-      addSpace = !allowedTags.includes(tag);
+    onOpenTag: (tagName, attribs) => {
+      addSpace = !allowedTags.includes(tagName);
     },
-    onCloseTag: (tag) => {
-      addSpace = !allowedTags.includes(tag);
+    onCloseTag: (tagName, isImplied) => {
+      addSpace = !allowedTags.includes(tagName);
     },
     textFilter: (text) => {
       if (addSpace) {

--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ For example, you may want to add spaces around a removed tag, like this:
 const allowedTags = [ 'b' ];
 let addSpace = false;
 const sanitizedHtml = sanitizeHtml(
-  'Text&#39;s here<div>it&#39;s here</div><div><p>it&#39;s there</p></div>and <b>also</b> here.',
+  'There should be<div><p>spaces</p></div>between <b>these</b> words.',
   {
     allowedTags,
     onOpenTag: (tag) => {
@@ -800,7 +800,7 @@ const sanitizedHtml = sanitizeHtml(
 
 In this example, we are setting a flag when a tag that will be removed has been opened or closed. Then we use the `textFilter` to modify the text to include spaces. The example should produce:
 ```
-Text's here it's here it's there and <b>also</b> here.
+There should be spaces between these words.
 ```
 
 ## About ApostropheCMS

--- a/README.md
+++ b/README.md
@@ -772,11 +772,11 @@ For more advanced filtering you can hook directly into the parsing process using
 
 The `onOpenTag` event is triggered when an opening tag is encountered. It has two arguments:
 - `tagName`: The name of the tag.
-- `attribs`: An object containing the tag's attributes, i.e. { src: "/path/to/tux.png" }.
+- `attribs`: An object containing the tag's attributes, e.g. `{ src: "/path/to/tux.png" }`.
 
 The `onCloseTag` event is triggered when a closing tag is encountered. It has the following arguments:
 - `tagName`: The name of the tag.
-- `isImplied`: A boolean indicating whether the closing tag is implied (i.e. `<p>foo<p>bar`) or explicit (i.e. `<p>foo</p><p>bar</p>`).
+- `isImplied`: A boolean indicating whether the closing tag is implied (e.g. `<p>foo<p>bar`) or explicit (e.g. `<p>foo</p><p>bar</p>`).
 
 For example, you may want to add spaces around a removed tag, like this:
 ```js

--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ const sanitizedHtml = sanitizeHtml(
 
 In this example, we are setting a flag when a tag that will be removed has been opened or closed. Then we use the `textFilter` to modify the text to include spaces. The example should produce:
 ```
-There should be spaces between these words.
+There should be spaces between <b>these</b> words.
 ```
 
 ## About ApostropheCMS

--- a/README.md
+++ b/README.md
@@ -768,10 +768,15 @@ This will prevent the user from nesting tags more than 6 levels deep. Tags deepe
 
 ### Advanced filtering
 
-For more advanced filtering you can hook directly into the parsing process using three events:
-- `onOpenTag(name, attribs)`: Triggered when an opening tag is encountered.
-- `onText(text)`: Triggered when a text node is encountered.
-- `onCloseTag(name, isImplied)`: Triggered when a closing tag is encountered.
+For more advanced filtering you can hook directly into the parsing process using tag open and tag close events.
+
+The `onOpenTag` event is triggered when an opening tag is encountered. It has two arguments:
+- `tagName`: The name of the tag.
+- `attribs`: An object containing the tag's attributes, i.e. { src: "/path/to/tux.png" }.
+
+The `onCloseTag` event is triggered when a closing tag is encountered. It has the following arguments:
+- `tagName`: The name of the tag.
+- `isImplied`: A boolean indicating whether the closing tag is implied (i.e. `<p>foo<p>bar`) or explicit (i.e. `<p>foo</p><p>bar</p>`).
 
 For example, you may want to add spaces around a removed tag, like this:
 ```js

--- a/README.md
+++ b/README.md
@@ -766,6 +766,43 @@ nestingLimit: 6
 
 This will prevent the user from nesting tags more than 6 levels deep. Tags deeper than that are stripped out exactly as if they were disallowed. Note that this means text is preserved in the usual ways where appropriate.
 
+### Advanced filtering
+
+For more advanced filtering you can hook directly into the parsing process using three events:
+- `onOpenTag(name, attribs)`: Triggered when an opening tag is encountered.
+- `onText(text)`: Triggered when a text node is encountered.
+- `onCloseTag(name, isImplied)`: Triggered when a closing tag is encountered.
+
+For example, you may want to add spaces around a removed tag, like this:
+```js
+const allowedTags = [ 'b' ];
+let addSpace = false;
+const sanitizedHtml = sanitizeHtml(
+  'Text&#39;s here<div>it&#39;s here</div><div><p>it&#39;s there</p></div>and <b>also</b> here.',
+  {
+    allowedTags,
+    onOpenTag: (tag) => {
+      addSpace = !allowedTags.includes(tag);
+    },
+    onCloseTag: (tag) => {
+      addSpace = !allowedTags.includes(tag);
+    },
+    textFilter: (text) => {
+      if (addSpace) {
+        addSpace = false;
+        return ' ' + text;
+      }
+      return text;
+    }
+  }
+);
+```
+
+In this example we are tracking when a removed tag has opened or closed and modify text that follows it. The example should produce:
+```
+Text's here it's here it's there and <b>also</b> here.
+```
+
 ## About ApostropheCMS
 
 sanitize-html was created at [P'unk Avenue](https://punkave.com) for use in [ApostropheCMS](https://apostrophecms.com), an open-source content management system built on Node.js. If you like sanitize-html you should definitely check out ApostropheCMS.

--- a/README.md
+++ b/README.md
@@ -823,6 +823,8 @@ In this example, we are setting a flag when a tag that will be removed has been 
 There should be spaces between <b>these</b> words.
 ```
 
+This is a simplified example that is not meant to be production-ready. For your specific case, you may want to keep track of currently open tags, using the open and close events to push and pop items on the stack, or only insert spaces next to a subset of disallowed tags.
+
 ## About ApostropheCMS
 
 sanitize-html was created at [P'unk Avenue](https://punkave.com) for use in [ApostropheCMS](https://apostrophecms.com), an open-source content management system built on Node.js. If you like sanitize-html you should definitely check out ApostropheCMS.

--- a/index.js
+++ b/index.js
@@ -513,10 +513,6 @@ function sanitizeHtml(html, options, _recursing) {
       }
     },
     ontext: function(text) {
-      if (options.onText) {
-        options.onText(text);
-      }
-
       if (skipText) {
         return;
       }

--- a/index.js
+++ b/index.js
@@ -219,6 +219,10 @@ function sanitizeHtml(html, options, _recursing) {
 
   const parser = new htmlparser.Parser({
     onopentag: function(name, attribs) {
+      if (options.onOpenTag) {
+        options.onOpenTag(name, attribs);
+      }
+
       // If `enforceHtmlBoundary` is `true` and this has found the opening
       // `html` tag, reset the state.
       if (options.enforceHtmlBoundary && name === 'html') {
@@ -509,6 +513,10 @@ function sanitizeHtml(html, options, _recursing) {
       }
     },
     ontext: function(text) {
+      if (options.onText) {
+        options.onText(text);
+      }
+
       if (skipText) {
         return;
       }
@@ -543,6 +551,9 @@ function sanitizeHtml(html, options, _recursing) {
       }
     },
     onclosetag: function(name, isImplied) {
+      if (options.onCloseTag) {
+        options.onCloseTag(name, isImplied);
+      }
 
       if (skipText) {
         skipTextDepth--;

--- a/test/test.js
+++ b/test/test.js
@@ -1724,7 +1724,7 @@ describe('sanitizeHtml', function() {
     const onOpenTag = sinon.spy();
     const onText = sinon.spy();
     const onCloseTag = sinon.spy();
-    const inputHtml = '<div>Some Text<p>paragraph content</p>some text</div>';
+    const inputHtml = '<div id="one">Some Text<p id="two">paragraph content</p>some text</div>';
     sanitizeHtml(inputHtml, {
       allowedTags: [ 'p' ],
       onOpenTag,
@@ -1732,22 +1732,30 @@ describe('sanitizeHtml', function() {
       onCloseTag
     });
     assert.equal(onOpenTag.callCount, 2);
+    assert.equal(onOpenTag.getCall(0).calledWith('div', { id: 'one' }), true);
+    assert.equal(onOpenTag.getCall(1).calledWith('p', { id: 'two' }), true);
     assert.equal(onText.callCount, 3);
+    assert.equal(onText.getCall(0).calledWith('Some Text'), true);
+    assert.equal(onText.getCall(1).calledWith('paragraph content'), true);
+    assert.equal(onText.getCall(2).calledWith('some text'), true);
     assert.equal(onCloseTag.callCount, 2);
+    assert.equal(onCloseTag.getCall(0).calledWith('p', false), true);
+    assert.equal(onCloseTag.getCall(1).calledWith('div', false), true);
   });
   it('should insert spaces between removed tags whose content we keep', () => {
-    const inputHtml = 'It&#39;s me<div>I&#39;m here</div><div>I&#39;m there</div>and also here';
-    const expectedOutput = 'It\'s me I\'m here I\'m there and also here';
+    const inputHtml = 'Text&#39;s here<div>it&#39;s here</div><div><p>it&#39;s there</p></div>and <b>also</b> here';
+    const expectedOutput = 'Text\'s here it\'s here it\'s there and <b>also</b> here';
+    const allowedTags = [ 'b' ];
     let addSpace = false;
     const sanitizedHtml = sanitizeHtml(
       inputHtml,
       {
-        allowedTags: [],
+        allowedTags,
         onOpenTag: (tag) => {
-          addSpace = true;
+          addSpace = !allowedTags.includes(tag);
         },
         onCloseTag: (tag) => {
-          addSpace = true;
+          addSpace = !allowedTags.includes(tag);
         },
         textFilter: (text) => {
           if (addSpace) {

--- a/test/test.js
+++ b/test/test.js
@@ -1720,4 +1720,19 @@ describe('sanitizeHtml', function() {
 
     assert.equal(sanitizedHtml, expectedOutput);
   });
+  it('should call onOpenTag, onText, and onCloseTag callbacks', () => {
+    const onOpenTag = sinon.spy();
+    const onText = sinon.spy();
+    const onCloseTag = sinon.spy();
+    const inputHtml = '<div>Some Text<p>paragraph content</p>some text</div>';
+    sanitizeHtml(inputHtml, {
+      allowedTags: [ 'p' ],
+      onOpenTag,
+      onText,
+      onCloseTag
+    });
+    assert.equal(onOpenTag.callCount, 2);
+    assert.equal(onText.callCount, 3);
+    assert.equal(onCloseTag.callCount, 2);
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1723,18 +1723,20 @@ describe('sanitizeHtml', function() {
   it('should call onOpenTag and onCloseTag callbacks', () => {
     const onOpenTag = sinon.spy();
     const onCloseTag = sinon.spy();
-    const inputHtml = '<div id="one">Some Text<p id="two">paragraph content</p>some text</div>';
+    const inputHtml = '<div id="one">Some Text<p id="two">paragraph content</p><p id="three">some text</div>';
     sanitizeHtml(inputHtml, {
       allowedTags: [ 'p' ],
       onOpenTag,
       onCloseTag
     });
-    assert.equal(onOpenTag.callCount, 2);
+    assert.equal(onOpenTag.callCount, 3);
     assert.equal(onOpenTag.getCall(0).calledWith('div', { id: 'one' }), true);
     assert.equal(onOpenTag.getCall(1).calledWith('p', { id: 'two' }), true);
-    assert.equal(onCloseTag.callCount, 2);
+    assert.equal(onOpenTag.getCall(2).calledWith('p', { id: 'three' }), true);
+    assert.equal(onCloseTag.callCount, 3);
     assert.equal(onCloseTag.getCall(0).calledWith('p', false), true);
-    assert.equal(onCloseTag.getCall(1).calledWith('div', false), true);
+    assert.equal(onCloseTag.getCall(1).calledWith('p', true), true);
+    assert.equal(onCloseTag.getCall(2).calledWith('div', false), true);
   });
   it('should insert spaces between removed tags whose content we keep', () => {
     const inputHtml = 'Text&#39;s here<div>it&#39;s here</div><div><p>it&#39;s there</p></div>and <b>also</b> here';

--- a/test/test.js
+++ b/test/test.js
@@ -1720,24 +1720,18 @@ describe('sanitizeHtml', function() {
 
     assert.equal(sanitizedHtml, expectedOutput);
   });
-  it('should call onOpenTag, onText, and onCloseTag callbacks', () => {
+  it('should call onOpenTag and onCloseTag callbacks', () => {
     const onOpenTag = sinon.spy();
-    const onText = sinon.spy();
     const onCloseTag = sinon.spy();
     const inputHtml = '<div id="one">Some Text<p id="two">paragraph content</p>some text</div>';
     sanitizeHtml(inputHtml, {
       allowedTags: [ 'p' ],
       onOpenTag,
-      onText,
       onCloseTag
     });
     assert.equal(onOpenTag.callCount, 2);
     assert.equal(onOpenTag.getCall(0).calledWith('div', { id: 'one' }), true);
     assert.equal(onOpenTag.getCall(1).calledWith('p', { id: 'two' }), true);
-    assert.equal(onText.callCount, 3);
-    assert.equal(onText.getCall(0).calledWith('Some Text'), true);
-    assert.equal(onText.getCall(1).calledWith('paragraph content'), true);
-    assert.equal(onText.getCall(2).calledWith('some text'), true);
     assert.equal(onCloseTag.callCount, 2);
     assert.equal(onCloseTag.getCall(0).calledWith('p', false), true);
     assert.equal(onCloseTag.getCall(1).calledWith('div', false), true);

--- a/test/test.js
+++ b/test/test.js
@@ -1735,4 +1735,29 @@ describe('sanitizeHtml', function() {
     assert.equal(onText.callCount, 3);
     assert.equal(onCloseTag.callCount, 2);
   });
+  it('should insert spaces between removed tags whose content we keep', () => {
+    const inputHtml = 'It&#39;s me<div>I&#39;m here</div><div>I&#39;m there</div>and also here';
+    const expectedOutput = 'It\'s me I\'m here I\'m there and also here';
+    let addSpace = false;
+    const sanitizedHtml = sanitizeHtml(
+      inputHtml,
+      {
+        allowedTags: [],
+        onOpenTag: (tag) => {
+          addSpace = true;
+        },
+        onCloseTag: (tag) => {
+          addSpace = true;
+        },
+        textFilter: (text) => {
+          if (addSpace) {
+            addSpace = false;
+            return ' ' + text;
+          }
+          return text;
+        }
+      }
+    );
+    assert.equal(sanitizedHtml, expectedOutput);
+  });
 });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Allows hooking into tag tag open, tag close, and text events of the parser to enable more advanced transformations such as inserting a space between two removed block-level tags with preserved text.

Closes #691.

## What are the specific steps to test this change?

Added a simple test in the test suite, but you can also test manually by passing the `onOpenTag`, `onCloseTag`, and `onText` listeners in the sanitizer options.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.
