### PR TITLE
Update test.js with linear-gradient support

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1767,4 +1767,13 @@ describe('sanitizeHtml', function() {
 
     assert.equal(sanitizedHtml, expectedOutput);
   });
+  it('should allow linear-gradient in background css property', () => {
+    const inputHtml = '<div style="background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(any_url) no-repeat center center;"></div>';
+    const expectedOutput = '<div style="background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(any_url) no-repeat center center;"></div>';
+    const sanitizedHtml = sanitizeHtml(inputHtml, {
+      allowedTags: ['div'],
+    });
+
+    assert.equal(sanitizedHtml, expectedOutput);
+  });
 });


### PR DESCRIPTION
Using the latest version of the package, it seems that linear-gradient in combination with url(), set in the background inside an inline style property will break the background.

Steps to reproduce :

Use CSS property & value : background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(any_url) no-repeat center center; in any html tag
Pass it to the sanitize function
The selected tag will have its background property entirely removed.

This test aims to check this behaviour