### PR TITLE
fix: support `text` for * transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.17.1 (2025-09-02)
+
+- Fix text option not being considered for transformTags when tag is *
+
 ## 2.17.0 (2025-05-14)
 
 - Add `preserveEscapedAttributes`, allowing attributes on escaped disallowed tags to be retained. Thanks to [Ben Elliot](https://github.com/benelliott) for this new option.

--- a/index.js
+++ b/index.js
@@ -258,6 +258,11 @@ function sanitizeHtml(html, options, _recursing) {
         transformedTag = transformTagsAll(name, attribs);
 
         frame.attribs = attribs = transformedTag.attribs;
+
+        if (transformedTag.text !== undefined) {
+          frame.innerText = transformedTag.text;
+        }
+        
         if (name !== transformedTag.tagName) {
           frame.name = name = transformedTag.tagName;
           transformMap[depth] = transformedTag.tagName;

--- a/test/test.js
+++ b/test/test.js
@@ -241,10 +241,23 @@ describe('sanitizeHtml', function() {
       }
     }), '<a href="http://somelink"></a>');
   });
-  it('should replace text and attributes when they are changed by transforming function and textFilter is set', function () {
+  it('should replace text and attributes when they are changed by transforming function', function () {
     assert.equal(sanitizeHtml('<a href="http://somelink">some text</a>', {
       transformTags: {
         a: function (tagName, attribs) {
+          return {
+            tagName: tagName,
+            attribs: attribs,
+            text: ''
+          };
+        }
+      }
+    }), '<a href="http://somelink"></a>');
+  });
+  it('should replace text and attributes for wildcard tag when they are changed by transforming function and textFilter is set', function () {
+    assert.equal(sanitizeHtml('<a href="http://somelink">some text</a>', {
+      transformTags: {
+        '*': function (tagName, attribs) {
           return {
             tagName: tagName,
             attribs: attribs,


### PR DESCRIPTION
## Allow text option for * transformer

There seems to be a bug where the text option doesn't work with the "any-tag" option:

```
const clean = sanitizeHtml("<p>Hello</p>", {
  transformTags: {
    'p': function(tagName, attribs) {
      return {
        tagName: 'p',
        text: 'Some text'
      };
    }
  }
});
// <p>Some text</p>
```

```
const clean = sanitizeHtml("<p>Hello</p>", {
  transformTags: {
    '*': function(tagName, attribs) {
      return {
        tagName: tagName,
        text: 'Some text'
      };
    }
  }
});
// expected: <p>Some text</p>
// actual: <p>Hello</p>
```

This PR fixes the scenario above.

## What are the specific steps to test this change?

See examples above

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a clear description of the bug it resolves. 
               Q: Did you want me to open a defect against the repo first, so I can reference the issue-id?
- [X] The changelog is updated
- [N/A] Related documentation has been updated
- [X] Related tests have been updated

