### PR TITLE
chore: upgrade htmlparser2 from 8.x to 10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Fix unclosed tags (e.g., `<hello`) returning empty string in `escape` and `recursiveEscape` modes. Fixes [#706](https://github.com/apostrophecms/sanitize-html/issues/706).
+- Upgrade `htmlparser2` from 8.x to 10.1.0. This improves security by correctly decoding zero-padded numeric character references (e.g., `&#0000001`) that previously bypassed `javascript:` URL detection. Also fixes double-encoding of entities inside raw text elements like `textarea` and `option`.
 
 ## 2.17.0 (2025-05-14)
 

--- a/index.js
+++ b/index.js
@@ -541,6 +541,11 @@ function sanitizeHtml(html, options, _recursing) {
         // your concern, don't allow them. The same is essentially true for style tags
         // which have their own collection of XSS vectors.
         result += text;
+      } else if ((options.disallowedTagsMode === 'discard' || options.disallowedTagsMode === 'completelyDiscard') && (nonTextTagsArray.indexOf(tag) !== -1)) {
+        // htmlparser2 does not decode entities inside raw text elements like
+        // textarea and option. The text is already properly encoded, so pass
+        // it through without additional escaping to avoid double-encoding.
+        result += text;
       } else if (!addedText) {
         const escaped = escapeHtml(text, false);
         if (options.textFilter) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "escape-string-regexp": "^4.0.0",
-    "htmlparser2": "^8.0.0",
+    "htmlparser2": "^10.1.0",
     "is-plain-object": "^5.0.0",
     "parse-srcset": "^1.0.2",
     "postcss": "^8.3.11"

--- a/test/test.js
+++ b/test/test.js
@@ -179,11 +179,14 @@ describe('sanitizeHtml', function() {
     assert.equal(sanitizeHtml('<a href="java\0&#14;\t\r\n script:alert(\'foo\')">Hax</a>'), '<a>Hax</a>');
   });
   it('should dump character codes 1-32 even when escaped with padding rather than trailing ;', function() {
-    assert.equal(sanitizeHtml('<a href="java&#0000001script:alert(\'foo\')">Hax</a>'), '<a href="java&amp;#0000001script:alert(\'foo\')">Hax</a>');
-    // This one is weird, but the browser does not interpret it
-    // as a scheme, so we're OK. That character is 65535, not null. I
-    // think it's a limitation of the entities module
-    assert.equal(sanitizeHtml('<a href="java&#0000000script:alert(\'foo\')">Hax</a>'), '<a href="java&amp;#0000000script:alert(\'foo\')">Hax</a>');
+    // htmlparser2 10.x correctly decodes zero-padded numeric entities.
+    // &#0000001 decodes to U+0001, which is stripped as a control char,
+    // revealing the javascript: scheme
+    assert.equal(sanitizeHtml('<a href="java&#0000001script:alert(\'foo\')">Hax</a>'), '<a>Hax</a>');
+    // &#0000000 decodes to U+FFFD (replacement character per HTML spec),
+    // which is not a control char, so the URL is preserved safely since
+    // browsers don't interpret java�script: as javascript:
+    assert.equal(sanitizeHtml('<a href="java&#0000000script:alert(\'foo\')">Hax</a>'), '<a href="java\uFFFDscript:alert(\'foo\')">Hax</a>');
   });
   it('should still like nice schemes', function() {
     assert.equal(sanitizeHtml('<a href="http://google.com/">Hi</a>'), '<a href="http://google.com/">Hi</a>');
@@ -874,6 +877,13 @@ describe('sanitizeHtml', function() {
       sanitizeHtml('!<textarea>&lt;/textarea&gt;&lt;svg/onload=prompt`xs`&gt;</textarea>!',
         { allowedTags: [ 'textarea' ] }
       ), '!<textarea>&lt;/textarea&gt;&lt;svg/onload=prompt`xs`&gt;</textarea>!'
+    );
+  });
+  it('should not double-encode entities inside an allowed textarea element', function() {
+    assert.equal(
+      sanitizeHtml('<textarea>&lt;div&gt;hello&lt;/div&gt;&amp;amp;</textarea>',
+        { allowedTags: [ 'textarea' ] }
+      ), '<textarea>&lt;div&gt;hello&lt;/div&gt;&amp;amp;</textarea>'
     );
   });
   it('should allow protocol relative links by default', function() {


### PR DESCRIPTION
## Summary
- Upgrades `htmlparser2` from `^8.0.0` to `^10.1.0`
- Fixes double-encoding of entities inside raw text elements like `textarea`
- Improves security: zero-padded numeric character references (e.g., `&#0000001`) are now correctly decoded, preventing `javascript:` URL bypass

## Test plan
- [x] All 191 existing tests pass
- [x] Added test for entity preservation inside allowed textarea elements